### PR TITLE
fixed notice banner arrow position, padding in text

### DIFF
--- a/src/components/Notice.vue
+++ b/src/components/Notice.vue
@@ -7,8 +7,7 @@
     >
       <div class="notice">
         <span>
-          <b>Nov prikaz po občinah: </b>
-          nov prikaz za aktivne primere, umrle in oceno prebolelih v posamezni občini.
+          <b>Nov prikaz po občinah:</b>Nov prikaz za aktivne primere, umrle in oceno prebolelih v posamezni občini.
         </span>
         <div class="notice-button">
           <img src="../assets/svg/go-to.svg" alt="Go to news" />
@@ -52,12 +51,17 @@
   }
 
   @media only screen and (min-width: 768px) {
-    padding: 20px 32px;
+    padding: 20px 24px 20px 32px;
   }
 
   &-button {
     margin-left: 16px;
   }
+
+  span b {
+    padding-right: 8px;
+  }
+
 }
 
 </style>


### PR DESCRIPTION
fixed notice banner arrow position
added 8px padding after colon
capitalised first word after colon

![Screenshot 2020-05-17 at 13 25 47](https://user-images.githubusercontent.com/52170374/82143147-ed509980-9841-11ea-8cbe-a023c97e45f8.jpg)
