### PR TITLE
github btn fixes

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -372,7 +372,7 @@ export default {
 .router-link {
   position: relative;
   display: block;
-  color: rgba(0, 0, 0, 0.5);
+  color: rgba(0, 0, 0, 0.56);
   font-size: 14px;
   line-height: 20px;
   padding: 9px 0;
@@ -420,10 +420,15 @@ export default {
   }
 
   &.router-link-icon {
+    border: 1px solid rgba(0, 0, 0, 0.13);
+    border-radius: 6px;
+    padding: 2px 6px;
+    display: inline-block;
+    margin-top: 11px;
+
     @include nav-break {
-      border: 1px solid rgba(0, 0, 0, 0.13);
-      border-radius: 8px;
-      padding: 0px 6px;
+      margin-top: 0;
+      padding: 0 6px;
     }
 
     span {


### PR DESCRIPTION
set github btn border radius to 6px,
added github btn border to mobile/tablet view
changed router-link color to: rgba(0, 0, 0, 0.56); in order to fix accessibility contrast ratios

![Screenshot 2020-05-18 at 11 51 02](https://user-images.githubusercontent.com/52170374/82199832-8513bd80-98fe-11ea-8a31-5e8f1b7282a9.jpg)
