### PR TITLE
info card mobile display, language toggle design

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -24,14 +24,16 @@
         <span>{{ $t("navbar.github") }}</span>
       </a>
       <div class="router-link">
-        <a href="#"
-           class="router-link-anchor"
-           :class="{ active: $i18n.i18next.language === 'sl' }"
-           @click.prevent="changeLanguage('sl')">SL</a> /
-        <a href="#"
-           class="router-link-anchor"
-           :class="{ active: $i18n.i18next.language === 'en' }"
-           @click.prevent="changeLanguage('en')">EN</a>
+        <span>
+          <a href="#"
+             class="router-link-anchor"
+             :class="{ active: $i18n.i18next.language === 'sl' }"
+             @click.prevent="changeLanguage('sl')">SL</a> /
+          <a href="#"
+             class="router-link-anchor"
+             :class="{ active: $i18n.i18next.language === 'en' }"
+             @click.prevent="changeLanguage('en')">EN</a>
+        </span>
       </div>
     </div>
   </div>
@@ -419,6 +421,7 @@ export default {
   span {
     line-height: 30px;
     display: inline-block;
+    // outline: 2px solid blue;
   }
 
   &.router-link-active {
@@ -441,10 +444,10 @@ export default {
     border-radius: 6px;
     padding: 0 6px;
     display: inline-block;
-    margin-top: 16px;
+    margin: 16px auto;
 
     @include nav-break {
-      margin-top: 0;
+      margin: 0 0 0 32px;
     }
 
     span {
@@ -469,11 +472,15 @@ export default {
   }
 
   &-anchor {
-    color: rgba(0, 0, 0, 0.5);
+    color: rgba(0, 0, 0, 0.56);
     text-decoration: none;
 
     &.active {
       font-weight: bold;
+    }
+
+    &:hover {
+      color: rgb(0, 0, 0);
     }
   }
 }

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -421,7 +421,6 @@ export default {
   span {
     line-height: 30px;
     display: inline-block;
-    // outline: 2px solid blue;
   }
 
   &.router-link-active {

--- a/src/components/cards/InfoCard.vue
+++ b/src/components/cards/InfoCard.vue
@@ -95,7 +95,7 @@ export default {
   flex: 0 0 100%;
   padding: 0 15px 15px;
 
-  @media only screen and (min-width: 480px) {
+  @media only screen and (min-width: 400px) {
     flex: 0 0 calc(100% / 2);
     padding: 0 15px 30px;
   }


### PR DESCRIPTION
- changed media query for info cards to 400px (displays 2 cards in one line on smaller screens)
- wrapped language toggle anchors in span (for proper mobile view nav-bar spacing)
- added language toggle hover states and fixed opacity for accessibility

![Screenshot_2020-05-24 COVID-19 Sledilnik (preview)(1)](https://user-images.githubusercontent.com/52170374/82750119-61dd8800-9dae-11ea-9837-517e39b5ee48.png)
![Screenshot_2020-05-24 COVID-19 Sledilnik (preview)(2)](https://user-images.githubusercontent.com/52170374/82750135-6a35c300-9dae-11ea-89ed-d114ab7bb8aa.png)
