### PR TITLE
fixed routes /sl/ & /en/ to redirect to stats page

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -129,6 +129,10 @@ const routes = [
     },
     children: [
       {
+        path:'/',
+        redirect: 'stats',
+      },
+      {
         path: 'stats',
         component: StatsPage,
       },


### PR DESCRIPTION
- fixed the issue seen in screenshot, where the path /sl/ or /en/ would load an empty page

![Screenshot 2020-06-01 at 10 26 18](https://user-images.githubusercontent.com/52170374/83390544-544d8100-a3f2-11ea-8fde-db176b98ed17.jpg)
