### PR TITLE
Implement remembering of range selection button.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,4 @@
 # TODO
 
 ## Remember range selection
-
-- implement an event handler that records button which was selected and
-    stores it to the chart state
-    - https://api.highcharts.com/highstock/rangeSelector.buttons.events
-- then render that state to `selected`
-- https://api.highcharts.com/highstock/rangeSelector
-- `selected`: The index of the button to appear pre-selected.
+- remove animation

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,10 @@
 # TODO
 
-## Countries comparison
-- shared tooltip is not working when x-axis is datetime, for some reason
-    - try fixing it 
-- add number of deaths in the tooltip
+## Remember range selection
+
+- implement an event handler that records button which was selected and
+    stores it to the chart state
+    - https://api.highcharts.com/highstock/rangeSelector.buttons.events
+- then render that state to `selected`
+- https://api.highcharts.com/highstock/rangeSelector
+- `selected`: The index of the button to appear pre-selected.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,6 @@
 # TODO
 
 ## Remember range selection
-- remove animation
+- disable animations
+- Struktura potrjeno okuženih doesn't work quite as it should
+- Potrjeno okuženi po regijah doesn't work - weird range selector

--- a/src/visualizations/CasesChart.fs
+++ b/src/visualizations/CasesChart.fs
@@ -1,11 +1,11 @@
 [<RequireQualifiedAccess>]
 module CasesChart
 
-open System
 open Elmish
 open Feliz
 open Feliz.ElmishComponents
 open Fable.Core.JsInterop
+open Browser
 
 open Types
 open Highcharts
@@ -16,10 +16,12 @@ type DisplayType =
 type State = {
     data: StatsData
     displayType: DisplayType
+    RangeSelectionButtonIndex: int
 }
 
 type Msg =
     | ChangeDisplayType of DisplayType
+    | RangeSelectionChanged of int
 
 type Series =
     | Deceased
@@ -51,6 +53,7 @@ let init data : State * Cmd<Msg> =
     let state = {
         data = data
         displayType = MultiChart
+        RangeSelectionButtonIndex = 0
     }
     state, Cmd.none
 
@@ -58,6 +61,8 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
     match msg with
     | ChangeDisplayType rt ->
         { state with displayType=rt }, Cmd.none
+    | RangeSelectionChanged buttonIndex ->
+        { state with RangeSelectionButtonIndex = buttonIndex }, Cmd.none
 
 let legendFormatter jsThis =
     let pts: obj[] = jsThis?points
@@ -80,7 +85,7 @@ let legendFormatter jsThis =
 
     fmtStr
 
-let renderChartOptions (state : State) =
+let renderChartOptions (state : State) dispatch =
     let className = "cases-chart"
     let scaleType = ScaleType.Linear
 
@@ -132,9 +137,16 @@ let renderChartOptions (state : State) =
             yield renderSeries series
     |]
 
+    let onRangeSelectorButtonClick(buttonIndex: int) =
+        let res (_ : Event) =
+            RangeSelectionChanged buttonIndex |> dispatch
+            true
+        res
+
     let baseOptions =
         Highcharts.basicChartOptions
-            scaleType className 0 (fun _ -> (fun _ -> true))
+            scaleType className
+            state.RangeSelectionButtonIndex onRangeSelectorButtonClick
     {| baseOptions with
         series = allSeries
         plotOptions = pojo
@@ -152,19 +164,19 @@ let renderChartOptions (state : State) =
 
     |}
 
-let renderChartContainer (state : State) =
+let renderChartContainer (state : State) dispatch =
     Html.div [
         prop.style [ style.height 480 ]
         prop.className "highcharts-wrapper"
         prop.children [
-            renderChartOptions state
+            renderChartOptions state dispatch
             |> Highcharts.chartFromWindow
         ]
     ]
 
 let render (state: State) dispatch =
     Html.div [
-        renderChartContainer state
+        renderChartContainer state dispatch
     ]
 
 let casesChart (props : {| data : StatsData |}) =

--- a/src/visualizations/CasesChart.fs
+++ b/src/visualizations/CasesChart.fs
@@ -132,7 +132,9 @@ let renderChartOptions (state : State) =
             yield renderSeries series
     |]
 
-    let baseOptions = Highcharts.basicChartOptions scaleType className
+    let baseOptions =
+        Highcharts.basicChartOptions
+            scaleType className 0 (fun _ -> (fun _ -> true))
     {| baseOptions with
         series = allSeries
         plotOptions = pojo

--- a/src/visualizations/CountriesChartViz/Rendering.fs
+++ b/src/visualizations/CountriesChartViz/Rendering.fs
@@ -158,6 +158,7 @@ let renderChartCode (state: ChartState) (chartData: ChartData) =
 
     let baseOptions =
         basicChartOptions state.ScaleType "covid19-metrics-comparison"
+            0 (fun _ -> (fun _ -> true))
     {| baseOptions with
         chart = pojo
             {|

--- a/src/visualizations/HCentersChart.fs
+++ b/src/visualizations/HCentersChart.fs
@@ -20,12 +20,14 @@ type State = {
     Error: string option
     Regions : Region list
     FilterByRegion : string
+    RangeSelectionButtonIndex: int
   }
 
 type Msg =
     | ConsumeHcData of Result<HcStats [], string>
     | ConsumeServerError of exn
     | RegionFilterChanged of string
+    | RangeSelectionChanged of int
 
 let init () : State * Cmd<Msg> =
     let cmd = Cmd.OfAsync.either Data.HCenters.getOrFetch () ConsumeHcData ConsumeServerError
@@ -35,6 +37,7 @@ let init () : State * Cmd<Msg> =
         Error = None
         Regions = [ ]
         FilterByRegion = ""
+        RangeSelectionButtonIndex = 0
     }
 
     state, (cmd)
@@ -57,8 +60,10 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
         { state with Error = Some ex.Message }, Cmd.none
     | RegionFilterChanged region ->
         { state with FilterByRegion = region }, Cmd.none
+    | RangeSelectionChanged buttonIndex ->
+        { state with RangeSelectionButtonIndex = buttonIndex }, Cmd.none
 
-let renderChartOptions (state : State) =
+let renderChartOptions (state : State) dispatch =
     let className = "hcenters-chart"
     let scaleType = ScaleType.Linear
     let startDate = DateTime(2020,3,18)
@@ -124,9 +129,16 @@ let renderChartOptions (state : State) =
 
     ]
 
+    let onRangeSelectorButtonClick(buttonIndex: int) =
+        let res (_ : Event) =
+            RangeSelectionChanged buttonIndex |> dispatch
+            true
+        res
+
     let baseOptions =
         Highcharts.basicChartOptions
-            scaleType className 0 (fun _ -> (fun _ -> true))
+            scaleType className
+            state.RangeSelectionButtonIndex onRangeSelectorButtonClick
     {| baseOptions with
         series = List.toArray allSeries
 
@@ -136,12 +148,12 @@ let renderChartOptions (state : State) =
         legend = pojo {| enabled = true ; layout = "horizontal" |}
     |}
 
-let renderChartContainer (state : State) =
+let renderChartContainer (state : State) dispatch =
     Html.div [
         prop.style [ style.height 480 ]
         prop.className "highcharts-wrapper"
         prop.children [
-            renderChartOptions state
+            renderChartOptions state dispatch
             |> Highcharts.chartFromWindow
         ]
     ]
@@ -181,7 +193,7 @@ let render (state : State) dispatch =
                     ]
                 ]
             ]
-            renderChartContainer state
+            renderChartContainer state dispatch
         ]
 
 

--- a/src/visualizations/HCentersChart.fs
+++ b/src/visualizations/HCentersChart.fs
@@ -71,7 +71,7 @@ let renderChartOptions (state : State) dispatch =
 
     let getRegionStats region mp =
             mp |> Map.find region
-            |> Map.fold ( fun total key hc -> total + hc ) TotalHcStats.None
+            |> Map.fold ( fun total _ hc -> total + hc ) TotalHcStats.None
 
     let hcData =
         match state.FilterByRegion with

--- a/src/visualizations/HCentersChart.fs
+++ b/src/visualizations/HCentersChart.fs
@@ -124,7 +124,9 @@ let renderChartOptions (state : State) =
 
     ]
 
-    let baseOptions = Highcharts.basicChartOptions scaleType className
+    let baseOptions =
+        Highcharts.basicChartOptions
+            scaleType className 0 (fun _ -> (fun _ -> true))
     {| baseOptions with
         series = List.toArray allSeries
 

--- a/src/visualizations/Highcharts.fs
+++ b/src/visualizations/Highcharts.fs
@@ -159,6 +159,7 @@ let basicChartOptions
     {|
         chart = pojo
             {|
+                animation = false
                 ``type`` = "line"
                 zoomType = "x"
                 className = className

--- a/src/visualizations/Highcharts.fs
+++ b/src/visualizations/Highcharts.fs
@@ -150,7 +150,12 @@ let optionsWithOnLoadEvent (className : string) =
         |}
     |}
 
-let basicChartOptions (scaleType:ScaleType) (className:string)=
+let basicChartOptions
+    (scaleType:ScaleType)
+    (className:string)
+    (selectedRangeSelectionButtonIndex: int)
+    (rangeSelectorButtonClickHandler: int -> (Event -> bool))
+    =
     {|
         chart = pojo
             {|
@@ -265,7 +270,7 @@ let basicChartOptions (scaleType:ScaleType) (className:string)=
             {|
                 enabled = true
                 allButtonsEnabled = true
-                selected = 0
+                selected = selectedRangeSelectionButtonIndex
                 inputDateFormat = I18N.t "charts.common.numDateFormat"
                 // TODO: https://www.highcharts.com/forum/viewtopic.php?t=17715
                 // inputEditDateFormat = I18N.t "charts.common.numDateFormat"
@@ -277,16 +282,19 @@ let basicChartOptions (scaleType:ScaleType) (className:string)=
                             ``type`` = "month"
                             count = 2
                             text = I18N.tOptions "charts.common.x_months" {| count = 2 |}
+                            events = pojo {| click = rangeSelectorButtonClickHandler 0 |}
                         |}
                         {|
                             ``type`` = "month"
                             count = 3
                             text = I18N.tOptions "charts.common.x_months" {| count = 3 |}
+                            events = pojo {| click = rangeSelectorButtonClickHandler 1 |}
                         |}
                         {|
                             ``type`` = "all"
                             count = 1
                             text = I18N.t "charts.common.all"
+                            events = pojo {| click = rangeSelectorButtonClickHandler 2 |}
                         |}
                     |]
             |}

--- a/src/visualizations/HospitalsChart.fs
+++ b/src/visualizations/HospitalsChart.fs
@@ -297,7 +297,9 @@ let renderChartOptions (state : State) =
         //yield renderFacilitiesSeries state.scope Vents Occupied clr Solid "Respiratorji, v uporabi"
     |]
 
-    let baseOptions = Highcharts.basicChartOptions state.scaleType "hospitals-chart"
+    let baseOptions =
+        Highcharts.basicChartOptions
+            state.scaleType "hospitals-chart" 0 (fun _ -> (fun _ -> true))
     {| baseOptions with
         yAxis = yAxes
         series = series

--- a/src/visualizations/HospitalsChart.fs
+++ b/src/visualizations/HospitalsChart.fs
@@ -5,6 +5,7 @@ open System
 open Elmish
 open Feliz
 open Feliz.ElmishComponents
+open Browser
 
 open Types
 open Data.Patients
@@ -24,6 +25,7 @@ type State = {
     error: string option
     facilities: FacilityCode list
     scope: Scope
+    RangeSelectionButtonIndex: int
   } with
     static member initial =
         {
@@ -33,6 +35,7 @@ type State = {
             error = None
             facilities = []
             scope = Totals
+            RangeSelectionButtonIndex = 0
         }
     static member switchBreakdown breakdown state = { state with scope = breakdown }
 
@@ -42,6 +45,7 @@ type Msg =
     | ConsumeServerError of exn
     | ScaleTypeChanged of ScaleType
     | SwitchBreakdown of Scope
+    | RangeSelectionChanged of int
 
 let init () : State * Cmd<Msg> =
     let cmd = Cmd.OfAsync.either Data.Hospitals.getOrFetch () ConsumeHospitalsData ConsumeServerError
@@ -71,6 +75,8 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
         { state with scaleType = scaleType }, Cmd.none
     | SwitchBreakdown breakdown ->
         (state |> State.switchBreakdown breakdown), Cmd.none
+    | RangeSelectionChanged buttonIndex ->
+        { state with RangeSelectionButtonIndex = buttonIndex }, Cmd.none
 
 let getAllScopes state = seq {
     yield Totals, I18N.t "charts.hospitals.allHospitals"
@@ -129,7 +135,7 @@ let extractPatientDataPoint scope cType : (PatientsStats -> (JsTimestamp * int o
             fa.JsDate12h, value
 
 
-let renderChartOptions (state : State) =
+let renderChartOptions (state : State) dispatch =
 
     let projectDays = 40
 
@@ -297,9 +303,16 @@ let renderChartOptions (state : State) =
         //yield renderFacilitiesSeries state.scope Vents Occupied clr Solid "Respiratorji, v uporabi"
     |]
 
+    let onRangeSelectorButtonClick(buttonIndex: int) =
+        let res (_ : Event) =
+            RangeSelectionChanged buttonIndex |> dispatch
+            true
+        res
+
     let baseOptions =
         Highcharts.basicChartOptions
-            state.scaleType "hospitals-chart" 0 (fun _ -> (fun _ -> true))
+            state.scaleType "hospitals-chart"
+            state.RangeSelectionButtonIndex onRangeSelectorButtonClick
     {| baseOptions with
         yAxis = yAxes
         series = series
@@ -345,12 +358,12 @@ let renderChartOptions (state : State) =
                 |}
     |}
 
-let renderChartContainer state =
+let renderChartContainer state dispatch =
     Html.div [
         prop.style [ style.height 480 ]
         prop.className "highcharts-wrapper"
         prop.children [
-            renderChartOptions state
+            renderChartOptions state dispatch
             |> Highcharts.chartFromWindow
         ]
     ]
@@ -514,7 +527,7 @@ let render (state : State) dispatch =
                 (Utils.renderScaleSelector
                     state.scaleType (ScaleTypeChanged >> dispatch))
 
-            renderChartContainer state
+            renderChartContainer state dispatch
             //Html.div [ prop.style [ style.height 10 ] ]
             renderBreakdownSelectors state dispatch
             Html.div [

--- a/src/visualizations/InfectionsChart.fs
+++ b/src/visualizations/InfectionsChart.fs
@@ -6,7 +6,6 @@ open System
 open Elmish
 open Feliz
 open Feliz.ElmishComponents
-
 open Browser
 
 open Highcharts
@@ -90,15 +89,18 @@ let availableDisplayTypes: DisplayType array = [|
 type State = {
     DisplayType : DisplayType
     Data : StatsData
+    RangeSelectionButtonIndex: int
 }
 
 type Msg =
     | ChangeDisplayType of DisplayType
+    | RangeSelectionChanged of int
 
 let init data : State * Cmd<Msg> =
     let state = {
         Data = data
         DisplayType = availableDisplayTypes.[0]
+        RangeSelectionButtonIndex = 0
     }
     state, Cmd.none
 
@@ -106,8 +108,10 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
     match msg with
     | ChangeDisplayType rt ->
         { state with DisplayType=rt }, Cmd.none
+    | RangeSelectionChanged buttonIndex ->
+        { state with RangeSelectionButtonIndex = buttonIndex }, Cmd.none
 
-let renderChartOptions displayType (data : StatsData) =
+let renderChartOptions state dispatch =
 
     let xAxisPoint (dp: StatsDataPoint) = dp.Date
 
@@ -137,7 +141,7 @@ let renderChartOptions displayType (data : StatsData) =
             |> skipLeadingMissing
             |> List.rev
 
-        data
+        state.Data
         |> List.map (fun dp -> ((xAxisPoint dp |> jsTime12h), pointData dp))
         |> skipLeadingMissing
         |> skipTrailingMissing
@@ -164,11 +168,11 @@ let renderChartOptions displayType (data : StatsData) =
 
     let allSeries = [
         let allMetricsData =
-            Metrics.metricsToDisplay displayType.ShowAllOrOthers
+            Metrics.metricsToDisplay state.DisplayType.ShowAllOrOthers
             |> Seq.map(fun metric ->
                 let data =
                     let runningTotals = calcRunningTotals metric
-                    match displayType.ValueTypes with
+                    match state.DisplayType.ValueTypes with
                     | RunningTotals -> runningTotals |> toFloatValues
                     | MovingAverages ->
                         runningTotals |> toDailyValues
@@ -200,14 +204,21 @@ let renderChartOptions displayType (data : StatsData) =
         let startDate = allDates |> Seq.min
         let endDate = allDates |> Seq.max |> Some
 
-        if displayType.ShowPhases then
+        if state.DisplayType.ShowPhases then
             yield addContainmentMeasuresFlags startDate endDate |> pojo
     ]
+
+    let onRangeSelectorButtonClick(buttonIndex: int) =
+        let res (_ : Event) =
+            RangeSelectionChanged buttonIndex |> dispatch
+            true
+        res
 
     let className = "covid19-infections"
     let baseOptions =
         Highcharts.basicChartOptions
-            ScaleType.Linear className 0 (fun _ -> (fun _ -> true))
+            ScaleType.Linear className
+            state.RangeSelectionButtonIndex onRangeSelectorButtonClick
 
     let axisWithPhases() = baseOptions.xAxis
 
@@ -222,8 +233,9 @@ let renderChartOptions displayType (data : StatsData) =
     {| baseOptions with
         chart = pojo
             {|
+                animation = false
                 ``type`` =
-                    match displayType.ChartType with
+                    match state.DisplayType.ChartType with
                     | SplineChart -> "spline"
                     | StackedBarNormal -> "column"
                     | StackedBarPercent -> "column"
@@ -234,16 +246,16 @@ let renderChartOptions displayType (data : StatsData) =
         title = pojo {| text = None |}
         series = List.toArray allSeries
         xAxis =
-            if displayType.ShowPhases then axisWithPhases()
+            if state.DisplayType.ShowPhases then axisWithPhases()
             else axisWithWithoutPhases()
         yAxis =     // need to hide negative label for addContainmentMeasuresFlags
-            let showFirstLabel = not displayType.ShowPhases
+            let showFirstLabel = not state.DisplayType.ShowPhases
             baseOptions.yAxis |> Array.map (fun ax -> {| ax with showFirstLabel = Some showFirstLabel |})
 
         plotOptions = pojo
             {|
                 series =
-                    match displayType.ChartType with
+                    match state.DisplayType.ChartType with
                     | SplineChart -> pojo {| stacking = ""; |}
                     | StackedBarNormal -> pojo {| stacking = "normal" |}
                     | StackedBarPercent -> pojo {| stacking = "percent" |}
@@ -251,12 +263,12 @@ let renderChartOptions displayType (data : StatsData) =
         legend = pojo {| enabled = true ; layout = "horizontal" |}
     |}
 
-let renderChartContainer data metrics =
+let renderChartContainer state dispatch =
     Html.div [
         prop.style [ style.height 480 ]
         prop.className "highcharts-wrapper"
         prop.children [
-            renderChartOptions data metrics
+            renderChartOptions state dispatch
             |> Highcharts.chartFromWindow
         ]
     ]
@@ -295,7 +307,7 @@ let lastDateOfGraph =
 
 let render state dispatch =
     Html.div [
-        renderChartContainer state.DisplayType state.Data
+        renderChartContainer state dispatch
         renderDisplaySelectors state.DisplayType (ChangeDisplayType >> dispatch)
     ]
 

--- a/src/visualizations/InfectionsChart.fs
+++ b/src/visualizations/InfectionsChart.fs
@@ -205,7 +205,9 @@ let renderChartOptions displayType (data : StatsData) =
     ]
 
     let className = "covid19-infections"
-    let baseOptions = Highcharts.basicChartOptions ScaleType.Linear className
+    let baseOptions =
+        Highcharts.basicChartOptions
+            ScaleType.Linear className 0 (fun _ -> (fun _ -> true))
 
     let axisWithPhases() = baseOptions.xAxis
 

--- a/src/visualizations/MetricsComparisonChart.fs
+++ b/src/visualizations/MetricsComparisonChart.fs
@@ -3,8 +3,10 @@ module MetricsComparisonChart
 
 open System
 open Elmish
+open Fable.Core
 open Feliz
 open Feliz.ElmishComponents
+open Browser
 
 open Highcharts
 open Types
@@ -60,17 +62,21 @@ module Metrics  =
 type State =
     { ScaleType : ScaleType
       Data : StatsData
-      Metrics : Metrics }
+      Metrics : Metrics
+      RangeSelectionButtonIndex: int
+    }
 
 type Msg =
     | ToggleMetricVisible of Metric
     | ScaleTypeChanged of ScaleType
+    | RangeSelectionChanged of int
 
 let init data : State * Cmd<Msg> =
     let state = {
         ScaleType = Linear
         Data = data
         Metrics = Metrics.initial
+        RangeSelectionButtonIndex = 0
     }
     state, Cmd.none
 
@@ -82,8 +88,10 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
         }, Cmd.none
     | ScaleTypeChanged scaleType ->
         { state with ScaleType = scaleType }, Cmd.none
+    | RangeSelectionChanged buttonIndex ->
+        { state with RangeSelectionButtonIndex = buttonIndex }, Cmd.none
 
-let renderChartOptions (scaleType: ScaleType) (data : StatsData) (metrics : Metrics) =
+let renderChartOptions state dispatch =
     let xAxisPoint (dp: StatsDataPoint) = dp.Date
 
     let metricDataGenerator mc =
@@ -106,7 +114,7 @@ let renderChartOptions (scaleType: ScaleType) (data : StatsData) (metrics : Metr
 
     let allSeries = [
         let mutable startTime = DateTime.Today |> jsTime
-        for metric in metrics do
+        for metric in state.Metrics do
             let pointData = metricDataGenerator metric
             yield pojo
                 {|
@@ -115,7 +123,7 @@ let renderChartOptions (scaleType: ScaleType) (data : StatsData) (metrics : Metr
                     name = I18N.tt "charts.metricsComparison" metric.Id
                     dashStyle = metric.Line |> DashStyle.toString
                     data =
-                        data
+                        state.Data
                         |> Seq.map (fun dp -> (xAxisPoint dp |> jsTime12h, pointData dp))
                         |> Seq.skipWhile (fun (ts,value) ->
                             if metric.Visible && value.IsSome then
@@ -126,20 +134,29 @@ let renderChartOptions (scaleType: ScaleType) (data : StatsData) (metrics : Metr
         yield addContainmentMeasuresFlags startTime None |> pojo
     ]
 
-    let baseOptions = basicChartOptions scaleType "covid19-metrics-comparison"
+    let onRangeSelectorButtonClick(buttonIndex: int) =
+        let res (_ : Event) =
+            RangeSelectionChanged buttonIndex |> dispatch
+            true
+        res
+
+    let baseOptions =
+        basicChartOptions state.ScaleType "covid19-metrics-comparison"
+            state.RangeSelectionButtonIndex
+            onRangeSelectorButtonClick
     {| baseOptions with
         series = List.toArray allSeries
         yAxis =
-            let showFirstLabel = scaleType <> Linear
+            let showFirstLabel = state.ScaleType <> Linear
             baseOptions.yAxis |> Array.map (fun ax -> {| ax with showFirstLabel = Some showFirstLabel |})
     |}
 
-let renderChartContainer scaleType data metrics =
+let renderChartContainer state dispatch =
     Html.div [
         prop.style [ style.height 480 ] //; style.width 500; ]
         prop.className "highcharts-wrapper"
         prop.children [
-            renderChartOptions scaleType data metrics
+            renderChartOptions state dispatch
             |> Highcharts.chartFromWindow
         ]
     ]
@@ -169,7 +186,7 @@ let render state dispatch =
         Utils.renderChartTopControlRight
             (Utils.renderScaleSelector
                 state.ScaleType (ScaleTypeChanged >> dispatch))
-        renderChartContainer state.ScaleType state.Data state.Metrics
+        renderChartContainer state dispatch
         renderMetricsSelectors state.Metrics dispatch
     ]
 

--- a/src/visualizations/MetricsComparisonChart.fs
+++ b/src/visualizations/MetricsComparisonChart.fs
@@ -3,7 +3,6 @@ module MetricsComparisonChart
 
 open System
 open Elmish
-open Fable.Core
 open Feliz
 open Feliz.ElmishComponents
 open Browser

--- a/src/visualizations/PatientsChart.fs
+++ b/src/visualizations/PatientsChart.fs
@@ -215,10 +215,10 @@ let renderStructureChart (state : State) dispatch =
             | InHospitalOut         -> fun ps -> ps.inHospital.out |> Utils.zeroToNone
             | InHospitalDeceased    -> fun ps -> ps.deceased.today |> Utils.zeroToNone
 
-        let color, seriesid = Series.getSeriesInfo series
+        let color, seriesId = Series.getSeriesInfo series
         {|
             color = color
-            name = I18N.tt "charts.patients" seriesid
+            name = I18N.tt "charts.patients" seriesId
             data =
                 psData
                 |> Seq.map (fun (date,ps) ->
@@ -227,7 +227,7 @@ let renderStructureChart (state : State) dispatch =
                         y = getPoint ps
                         fmtTotal = getPointTotal ps |> string
                         fmtDate = I18N.tOptions "days.longerDate" {| date = date |}
-                        seriesId = seriesid
+                        seriesId = seriesId
                     |} )
                 |> Seq.toArray
         |} |> pojo

--- a/src/visualizations/PatientsChart.fs
+++ b/src/visualizations/PatientsChart.fs
@@ -127,7 +127,10 @@ let renderByHospitalChart (state : State) =
             showInLegend = true
         |} |> pojo
 
-    let baseOptions = Highcharts.basicChartOptions ScaleType.Linear "covid19-patients-by-hospital"
+    let baseOptions =
+        Highcharts.basicChartOptions
+            ScaleType.Linear "covid19-patients-by-hospital"
+            0 (fun _ -> (fun _ -> true))
     {| baseOptions with
 
         series = [| for fcode in state.AllFacilities do yield renderSources fcode |]
@@ -219,7 +222,10 @@ let renderStructureChart (state : State) =
 
 
     let className = "covid19-patients-structure"
-    let baseOptions = Highcharts.basicChartOptions ScaleType.Linear className
+    let baseOptions =
+        Highcharts.basicChartOptions
+            ScaleType.Linear className
+            0 (fun _ -> (fun _ -> true))
     {| baseOptions with
         chart = pojo
             {|

--- a/src/visualizations/PatientsChart.fs
+++ b/src/visualizations/PatientsChart.fs
@@ -6,6 +6,7 @@ open Elmish
 open Feliz
 open Feliz.ElmishComponents
 open Fable.Core.JsInterop
+open Browser
 
 open Highcharts
 open Types
@@ -52,6 +53,7 @@ type State = {
     Error : string option
     AllFacilities : string list
     Breakdown : Breakdown
+    RangeSelectionButtonIndex: int
   } with
     static member initial =
         {
@@ -59,6 +61,7 @@ type State = {
             Error = None
             AllFacilities = []
             Breakdown = AllHospitals
+            RangeSelectionButtonIndex = 0
         }
 
 let getAllBreakdowns state = seq {
@@ -72,6 +75,7 @@ type Msg =
     | ConsumePatientsData of Result<PatientsStats [], string>
     | ConsumeServerError of exn
     | SwitchBreakdown of Breakdown
+    | RangeSelectionChanged of int
 
 let init () : State * Cmd<Msg> =
     let cmd = Cmd.OfAsync.either Data.Patients.getOrFetch () ConsumePatientsData ConsumeServerError
@@ -99,8 +103,10 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
         { state with Error = Some ex.Message }, Cmd.none
     | SwitchBreakdown breakdown ->
         { state with Breakdown = breakdown }, Cmd.none
+    | RangeSelectionChanged buttonIndex ->
+        { state with RangeSelectionButtonIndex = buttonIndex }, Cmd.none
 
-let renderByHospitalChart (state : State) =
+let renderByHospitalChart (state : State) dispatch =
 
     let startDate = DateTime(2020,03,10)
 
@@ -127,10 +133,16 @@ let renderByHospitalChart (state : State) =
             showInLegend = true
         |} |> pojo
 
+    let onRangeSelectorButtonClick(buttonIndex: int) =
+        let res (_ : Event) =
+            RangeSelectionChanged buttonIndex |> dispatch
+            true
+        res
+
     let baseOptions =
         Highcharts.basicChartOptions
             ScaleType.Linear "covid19-patients-by-hospital"
-            0 (fun _ -> (fun _ -> true))
+            state.RangeSelectionButtonIndex onRangeSelectorButtonClick
     {| baseOptions with
 
         series = [| for fcode in state.AllFacilities do yield renderSources fcode |]
@@ -142,7 +154,7 @@ let renderByHospitalChart (state : State) =
     |} |> pojo
 
 
-let renderStructureChart (state : State) =
+let renderStructureChart (state : State) dispatch =
 
     let startDate = DateTime(2020,03,10)
 
@@ -220,15 +232,21 @@ let renderStructureChart (state : State) =
                 |> Seq.toArray
         |} |> pojo
 
+    let onRangeSelectorButtonClick(buttonIndex: int) =
+        let res (_ : Event) =
+            RangeSelectionChanged buttonIndex |> dispatch
+            true
+        res
 
     let className = "covid19-patients-structure"
     let baseOptions =
         Highcharts.basicChartOptions
             ScaleType.Linear className
-            0 (fun _ -> (fun _ -> true))
+            state.RangeSelectionButtonIndex onRangeSelectorButtonClick
     {| baseOptions with
         chart = pojo
             {|
+                animation = false
                 ``type`` = "column"
                 zoomType = "x"
                 className = className
@@ -248,14 +266,18 @@ let renderStructureChart (state : State) =
     |} |> pojo
 
 
-let renderChartContainer state =
+let renderChartContainer state dispatch =
     Html.div [
         prop.style [ style.height 480 ]
         prop.className "highcharts-wrapper"
         prop.children [
             match state.Breakdown with
-            | ByHospital -> renderByHospitalChart state |> Highcharts.chartFromWindow
-            | _ -> renderStructureChart state |> Highcharts.chartFromWindow
+            | ByHospital ->
+                renderByHospitalChart state dispatch
+                |> Highcharts.chartFromWindow
+            | _ ->
+                renderStructureChart state dispatch
+                |> Highcharts.chartFromWindow
         ]
     ]
 
@@ -279,7 +301,7 @@ let render (state : State) dispatch =
     | _, Some err -> Html.div [ Utils.renderErrorLoading err ]
     | _, None ->
         Html.div [
-            renderChartContainer state
+            renderChartContainer state dispatch
             renderBreakdownSelectors state dispatch
         ]
 

--- a/src/visualizations/RatiosChart.fs
+++ b/src/visualizations/RatiosChart.fs
@@ -128,8 +128,6 @@ let renderRatiosChart (state : State) dispatch =
             | DeceasedIcuDeceasedTotal      -> fun ps -> ps.JsDate12h, percent ps.total.deceased.hospital.icu.toDate ps.total.deceased.toDate
             | DeceasedHospitalDeceasedTotal -> fun ps -> ps.JsDate12h, percent ps.total.deceased.hospital.toDate ps.total.deceased.toDate
 
-        let color, line, name = Ratios.getSeriesInfo ratio
-
         let color, line, id = Ratios.getSeriesInfo ratio
         {|
             visible = true

--- a/src/visualizations/RatiosChart.fs
+++ b/src/visualizations/RatiosChart.fs
@@ -5,7 +5,7 @@ open System
 open Elmish
 open Feliz
 open Feliz.ElmishComponents
-open Fable.Core.JsInterop
+open Browser
 
 open Highcharts
 open Types
@@ -65,12 +65,14 @@ type State = {
     patientsData : PatientsStats []
     error: string option
     displayType: DisplayType
+    RangeSelectionButtonIndex: int
 }
 
 type Msg =
     | ConsumePatientsData of Result<PatientsStats [], string>
     | ConsumeServerError of exn
     | ChangeDisplayType of DisplayType
+    | RangeSelectionChanged of int
 
 let init (data : StatsData) : State * Cmd<Msg> =
     let state = {
@@ -78,6 +80,7 @@ let init (data : StatsData) : State * Cmd<Msg> =
         patientsData = [||]
         error = None
         displayType = Cases
+        RangeSelectionButtonIndex = 0
     }
     let cmd = Cmd.OfAsync.either Data.Patients.getOrFetch () ConsumePatientsData ConsumeServerError
     state, cmd
@@ -92,9 +95,11 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
         { state with error = Some ex.Message }, Cmd.none
     | ChangeDisplayType dt ->
         { state with displayType = dt }, Cmd.none
+    | RangeSelectionChanged buttonIndex ->
+        { state with RangeSelectionButtonIndex = buttonIndex }, Cmd.none
 
 
-let renderRatiosChart (state : State) =
+let renderRatiosChart (state : State) dispatch =
 
     let startDate = DateTime(2020,03,10)
 
@@ -139,15 +144,21 @@ let renderRatiosChart (state : State) =
         |}
         |> pojo
 
+    let onRangeSelectorButtonClick(buttonIndex: int) =
+        let res (_ : Event) =
+            RangeSelectionChanged buttonIndex |> dispatch
+            true
+        res
 
-    let maxValue = if state.displayType = Mortality then Some 100 else None
     let className = DisplayType.getClassName state.displayType
     let baseOptions =
         Highcharts.basicChartOptions
-            ScaleType.Linear className 0 (fun _ -> (fun _ -> true))
+            ScaleType.Linear className
+            state.RangeSelectionButtonIndex onRangeSelectorButtonClick
     {| baseOptions with
         chart = pojo
             {|
+                animation = false
                 ``type`` = "spline"
                 zoomType = "x"
                 className = className
@@ -168,11 +179,13 @@ let renderRatiosChart (state : State) =
         legend = pojo {| enabled = true ; layout = "horizontal" |}
 |}
 
-let renderChartContainer state =
+let renderChartContainer state dispatch =
     Html.div [
         prop.style [ style.height 480 ]
         prop.className "highcharts-wrapper"
-        prop.children [ renderRatiosChart state  |> Highcharts.chartFromWindow ]
+        prop.children [
+            renderRatiosChart state dispatch |> Highcharts.chartFromWindow
+        ]
     ]
 
 let renderDisplaySelector state dt dispatch =
@@ -195,7 +208,7 @@ let render (state : State) dispatch =
     | _, Some err -> Html.div [ Utils.renderErrorLoading err ]
     | _, None ->
         Html.div [
-            renderChartContainer state
+            renderChartContainer state dispatch
             renderDisplaySelectors state dispatch
         ]
 

--- a/src/visualizations/RatiosChart.fs
+++ b/src/visualizations/RatiosChart.fs
@@ -142,7 +142,9 @@ let renderRatiosChart (state : State) =
 
     let maxValue = if state.displayType = Mortality then Some 100 else None
     let className = DisplayType.getClassName state.displayType
-    let baseOptions = Highcharts.basicChartOptions ScaleType.Linear className
+    let baseOptions =
+        Highcharts.basicChartOptions
+            ScaleType.Linear className 0 (fun _ -> (fun _ -> true))
     {| baseOptions with
         chart = pojo
             {|

--- a/src/visualizations/RegionsChart.fs
+++ b/src/visualizations/RegionsChart.fs
@@ -107,7 +107,10 @@ let renderChartOptions (state : State) =
         )
         |> List.toArray
 
-    let baseOptions = Highcharts.basicChartOptions state.ScaleType "covid19-regions"
+    let baseOptions =
+        Highcharts.basicChartOptions
+            state.ScaleType "covid19-regions"
+            0 (fun _ -> (fun _ -> true))
     {| baseOptions with
         chart = pojo
             {|

--- a/src/visualizations/RegionsChart.fs
+++ b/src/visualizations/RegionsChart.fs
@@ -5,6 +5,7 @@ open Elmish
 
 open Feliz
 open Feliz.ElmishComponents
+open Browser
 
 open Highcharts
 open Types
@@ -34,11 +35,14 @@ type State =
     { ScaleType : ScaleType
       Data : RegionsData
       Regions : Region list
-      Metrics : Metric list }
+      Metrics : Metric list
+      RangeSelectionButtonIndex: int
+      }
 
 type Msg =
     | ToggleRegionVisible of string
     | ScaleTypeChanged of ScaleType
+    | RangeSelectionChanged of int
 
 let regionTotal (region : Region) : int =
     region.Municipalities
@@ -59,7 +63,9 @@ let init (data : RegionsData) : State * Cmd<Msg> =
               Color = color
               Visible = i <= 2 } ) colors
 
-    { ScaleType = Linear ; Data = data ; Regions = regions ; Metrics = metrics }, Cmd.none
+    { ScaleType = Linear ; Data = data ; Regions = regions ; Metrics = metrics
+      RangeSelectionButtonIndex = 0 },
+    Cmd.none
 
 let update (msg: Msg) (state: State) : State * Cmd<Msg> =
     match msg with
@@ -73,8 +79,10 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
         { state with Metrics = newMetrics }, Cmd.none
     | ScaleTypeChanged scaleType ->
         { state with ScaleType = scaleType }, Cmd.none
+    | RangeSelectionChanged buttonIndex ->
+        { state with RangeSelectionButtonIndex = buttonIndex }, Cmd.none
 
-let renderChartOptions (state : State) =
+let renderChartOptions (state : State) dispatch =
 
     let metricsToRender =
         state.Metrics
@@ -107,13 +115,20 @@ let renderChartOptions (state : State) =
         )
         |> List.toArray
 
+    let onRangeSelectorButtonClick(buttonIndex: int) =
+        let res (_ : Event) =
+            RangeSelectionChanged buttonIndex |> dispatch
+            true
+        res
+
     let baseOptions =
         Highcharts.basicChartOptions
             state.ScaleType "covid19-regions"
-            0 (fun _ -> (fun _ -> true))
+            state.RangeSelectionButtonIndex onRangeSelectorButtonClick
     {| baseOptions with
         chart = pojo
             {|
+                animation = false
                 ``type`` = "line"
                 zoomType = "x"
                 styledMode = false // <- set this to 'true' for CSS styling
@@ -123,12 +138,12 @@ let renderChartOptions (state : State) =
         legend = {| enabled = false |}
     |}
 
-let renderChartContainer state =
+let renderChartContainer state dispatch =
     Html.div [
         prop.style [ style.height 450 ] //; style.width 500; ]
         prop.className "highcharts-wrapper"
         prop.children [
-            renderChartOptions state
+            renderChartOptions state dispatch
             |> Highcharts.chartFromWindow
         ]
     ]
@@ -158,7 +173,7 @@ let render (state : State) dispatch =
         Utils.renderChartTopControlRight
             (Utils.renderScaleSelector
                 state.ScaleType (ScaleTypeChanged >> dispatch))
-        renderChartContainer state
+        renderChartContainer state dispatch
         renderMetricsSelectors state.Metrics dispatch
     ]
 

--- a/src/visualizations/SpreadChart.fs
+++ b/src/visualizations/SpreadChart.fs
@@ -205,7 +205,7 @@ let renderChartOptions scaleType state dispatch =
     |}
 
 let renderExplainer (data: StatsData) =
-    let curPositive, curHospitalzed, doublingRate =
+    let curPositive, curHospitalized =
         data
         |> List.rev
         |> Seq.choose (fun dp ->
@@ -214,7 +214,7 @@ let renderExplainer (data: StatsData) =
             | _, _ -> None)
         |> Seq.take 1
         |> Seq.toList |> List.head
-        |> fun (p, h) -> (p,h,7.0)
+        |> fun (p, h) -> (p,h)
 
     let box (title: string) times positive hospitalized =
         Html.div [
@@ -225,7 +225,7 @@ let renderExplainer (data: StatsData) =
                     match times with
                     | 0 -> Html.span ""
                     | 1 -> Html.span (sprintf "%d%s" (1<<<times) (I18N.t "charts.spread.timesAsMany"))
-                    | n -> Html.span (sprintf "%d%s" (1<<<times) (I18N.t "charts.spread.timesAsMany"))
+                    | _ -> Html.span (sprintf "%d%s" (1<<<times) (I18N.t "charts.spread.timesAsMany"))
                 ]
                 Html.div [ Html.h4 (string positive); Html.p [ Html.text (I18N.t "charts.spread.confirmed"); Html.br []; Html.text (I18N.t "charts.spread.cases")  ]]
                 Html.div [ Html.h4 (string hospitalized); Html.p (I18N.t "charts.spread.hoispitalized") ]
@@ -247,7 +247,7 @@ let renderExplainer (data: StatsData) =
                           I18N.t "charts.spread.inThreeWeeks", 3
                           I18N.t "charts.spread.inFourWeeks", 4 ]
                         |> List.map (fun (title, doublings) ->
-                            box title doublings (curPositive <<< doublings) (curHospitalzed <<< doublings)
+                            box title doublings (curPositive <<< doublings) (curHospitalized <<< doublings)
                         )
                 ]
             ]

--- a/src/visualizations/SpreadChart.fs
+++ b/src/visualizations/SpreadChart.fs
@@ -184,7 +184,9 @@ let renderChartOptions scaleType (data : StatsData) =
     |]
 
     // return highcharts options
-    {| basicChartOptions Linear "covid19-spread" with
+    {| basicChartOptions Linear "covid19-spread"
+            0 (fun _ -> (fun _ -> true))
+        with
         series = allSeries
         yAxis=chartCfg.yAxis
         legend= pojo {| enabled = true |}

--- a/src/visualizations/TestsChart.fs
+++ b/src/visualizations/TestsChart.fs
@@ -108,7 +108,9 @@ let renderChartOptions (state : State) =
             |}
     ]
 
-    let baseOptions = Highcharts.basicChartOptions scaleType className
+    let baseOptions =
+        Highcharts.basicChartOptions
+            scaleType className 0 (fun _ -> (fun _ -> true))
     {| baseOptions with
         yAxis = allYAxis
         series = List.toArray allSeries


### PR DESCRIPTION
Currently only implemented for MetricsComparisonChart, as an experiment. The common functionality for configuring the on-click event was added to `Highcharts.fs`, but now each of the charts needs a new state variable, new message and message handling (in `update()` function) and probably some other minor details.