### PR TITLE
Show only the first 1000 characters of error message

### DIFF
--- a/src/visualizations/data/Regions.fs
+++ b/src/visualizations/data/Regions.fs
@@ -77,5 +77,5 @@ let load =
                 let data = parseRegionsData response
                 return RegionsDataLoaded (Success data)
             with
-                | ex -> return RegionsDataLoaded (sprintf "Napaka pri branju statističnih podatkov: %s" ex.Message |> Failure)
+                | ex -> return RegionsDataLoaded (sprintf "Napaka pri branju statističnih podatkov: %s" (ex.Message.Substring(0, 1000)) |> Failure)
     }


### PR DESCRIPTION
When there is a problem with getting invalid JSON (eg cut off at the end for whatever reason) the error message can get very long:
![image](https://user-images.githubusercontent.com/319826/87233221-e8354400-c3c5-11ea-8115-189c9e71d33f.png)
...large document, slow DOM

This PR limits it to only first 1000 characters.

TODO:
* what happens when the error message is shorter than the 1000 characters?
* put similar limit in other error handlers?
* prefix i18n or just write them to english?
