### PR TITLE
ETags for comparisons

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,15 @@
 # TODO
 
+## Optimizations
+- extract getting the data to a common module
+
+- use ETag for comparison of data
+    - how to get it?
+        - replace existing Http.get with something that provides access
+            to response headers
+        - Fable.SimpleHttp.Http.get
+    - wrap loaded data in a generic class so ETag is always present 
+
 ## New countries chart
 - deaths per cases (windowed, averaged)
 

--- a/src/visualizations/PatientsChart.fs
+++ b/src/visualizations/PatientsChart.fs
@@ -2,6 +2,7 @@
 module PatientsChart
 
 open System
+open DataLoader
 open Elmish
 open Feliz
 open Feliz.ElmishComponents
@@ -72,13 +73,14 @@ let getAllBreakdowns state = seq {
     }
 
 type Msg =
-    | ConsumePatientsData of Result<PatientsStats [], string>
+    | ConsumePatientsData of Result<DownloadedData<PatientsStats []>, string>
     | ConsumeServerError of exn
     | SwitchBreakdown of Breakdown
     | RangeSelectionChanged of int
 
 let init () : State * Cmd<Msg> =
-    let cmd = Cmd.OfAsync.either getOrFetch () ConsumePatientsData ConsumeServerError
+    let cmd = Cmd.OfAsync.either
+                  getOrFetch () ConsumePatientsData ConsumeServerError
     State.initial, cmd
 
 let getFacilitiesList (data : PatientsStats array) =
@@ -102,7 +104,8 @@ let getFacilitiesList (data : PatientsStats array) =
 let update (msg: Msg) (state: State) : State * Cmd<Msg> =
     match msg with
     | ConsumePatientsData (Ok data) ->
-        { state with PatientsData = data; AllFacilities = getFacilitiesList data }, Cmd.none
+        { state with PatientsData = data.Data
+                     AllFacilities = getFacilitiesList data.Data }, Cmd.none
     | ConsumePatientsData (Error err) ->
         { state with Error = Some err }, Cmd.none
     | ConsumeServerError ex ->

--- a/src/visualizations/data/HCenters.fs
+++ b/src/visualizations/data/HCenters.fs
@@ -1,6 +1,7 @@
 module Data.HCenters
 
 open System
+open DataLoader
 
 let url = "https://api.sledilnik.org/api/health-centers"
 
@@ -65,5 +66,3 @@ type HcStats = {
     member ps.Date = DateTime(ps.year, ps.month, ps.day)
     member ps.JsDate12h = DateTime(ps.year, ps.month, ps.day)
                           |> Highcharts.Helpers.jsTime12h
-
-let getOrFetch = DataLoader.makeDataLoader<HcStats []> url

--- a/src/visualizations/data/Hospitals.fs
+++ b/src/visualizations/data/Hospitals.fs
@@ -106,6 +106,3 @@ let getSortedFacilityCodes (data: FacilityAssets []) =
             //printfn "hospital %s %A" fc cnt
             -quality, (if fc.Length = 3 then fc else "x"+fc))
         |> List.map fst
-
-
-let getOrFetch = DataLoader.makeDataLoader<FacilityAssets []> url

--- a/src/visualizations/data/Loader.fs
+++ b/src/visualizations/data/Loader.fs
@@ -1,27 +1,52 @@
 module DataLoader
 
+open Fable.Core
 open Fable.SimpleHttp
 open Fable.SimpleJson
 
-let inline makeDataLoader<'T>(url) =
-    let mutable cached = None
-    let fetch () = async {
-        let! code,json = Http.get url
+type DownloadedData<'T> = {
+    ETag: string
+    Data: 'T
+}
+
+let inline downloadData<'T>
+    (url: string)
+    (method: HttpMethod)
+    : Async<Result<DownloadedData<'T>, string>> =
+    async {
+        let! response =
+            Http.request url |> Http.method method |> Http.send
+
+        let code = response.statusCode
+
         return
             match code with
             | 200 ->
-                json
-                |> Json.parseNativeAs<'T>
-                |> Ok
+                let json = response.responseText
+
+                let etag =
+                    if response.responseHeaders.ContainsKey "ETag" then
+                        response.responseHeaders.["ETag"]
+                    else
+                        let xxx = sprintf "%s=%A" url response.responseHeaders
+                        JS.console.log xxx
+                        ""
+                let parsedData = json |> Json.parseNativeAs<'T>
+                Ok { Data = parsedData; ETag = etag }
             | _ ->
                 Error (sprintf "got http %d while fetching %s" code url)
     }
+
+let inline makeDataLoader<'T>(url) =
+    let mutable cached = None
+
     let getOrFetch () = async {
         match cached with
         | Some x -> return x
         | None ->
-            let! result = fetch ()
+            let! result = downloadData<'T> url GET
             cached <- Some result
             return result
     }
+
     getOrFetch


### PR DESCRIPTION
Attempting to use ETag as an efficient way to compare between the versions of downloaded objects (instead of using structural comparison).

Right now I have a problem that `Fable.SimpleHttp.HttpResponse.responseHeaders` do not contain `ETag `header, for some reason (although it is there, tested it in Chrome and Postman).