### PR TITLE
fix: Fix highcharts range selector translations

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -9,7 +9,7 @@ import de from './locales/de.json'
 import it from './locales/it.json'
 
 
-import Highcharts from 'highcharts'
+import {Highcharts} from './visualizations/_highcharts'
 
 Vue.use(VueI18Next)
 

--- a/src/visualizations/_highcharts.js
+++ b/src/visualizations/_highcharts.js
@@ -267,5 +267,6 @@ export {
     loadScript,
     renderChart,
     renderChartFromWindow,
-    renderMap
+    renderMap,
+    Highcharts
 }


### PR DESCRIPTION
Range Selector for Highcharts is in the Stock module. Stock module needs to be imported before translations for range selector can be set successfully. This PR changes imports to achieve that.