### PR TITLE
Updated color scheme for municipalities/regions 

### DIFF
--- a/src/visualizations/MapChart.fs
+++ b/src/visualizations/MapChart.fs
@@ -347,19 +347,46 @@ let renderMap (state : State) =
             let label = points?label
             sprintf "<b>%s</b><br/>%s<br/>" area label
 
+        let colors = [| 
+            "#ffffcc"
+            "#ffeda0"
+            "#fed976"
+            "#feb24c"
+            "#fd8d3c"
+            "#fc4e2a"
+            "#e31a1c"
+            "#b10026"
+         |] //colors from EuropeMapChart
+
         let maxValue = data |> Seq.map (fun dp -> dp.value) |> Seq.max
-        let maxColor =
-            if maxValue = 0. then
-                "white" // override for empty map
+
+        let classes =
+            [0..7] |> Seq.map (float) |> Seq.map((*) (float maxValue)) |> Seq.map( (*) 0.125) // 8 class labels  relative to maxValue 
+
+        // let maxColor =
+        //     if maxValue = 0. then
+        //         "white" // override for empty map
+        //     else
+        //         match state.ContentType with
+        //         | Deceased -> "#808080"
+        //         | ConfirmedCases -> "#e03000"
+        
+        let colorAxis = 
+            if maxValue = 0. then 
+                {| dataClassColor = "category"; dataClasses = [| {| from = 0; color = "#ffffcc" |} |] |} |> pojo //override for empty map
             else
-                match state.ContentType with
-                | Deceased -> "#808080"
-                | ConfirmedCases -> "#e03000"
+                let dataClasses = 
+                    Seq.zip classes colors 
+                    |> Seq.map( fun (cls, clr) -> {| from = cls; color = clr |} )        
+                    |> Seq.toArray
+                {| dataClassColor = "category"; dataClasses = dataClasses |} |> pojo
+
         {| Highcharts.optionsWithOnLoadEvent "covid19-map" with
             title = null
             series = [| series geoJson |]
             legend = {| enabled = false |}
-            colorAxis = {| minColor = "white" ; maxColor = maxColor |}
+            colorAxis = colorAxis
+            // colorAxis = {| minColor = "white" ; maxColor = maxColor |}
             tooltip =
                 {|
                     formatter = fun () -> tooltipFormatter jsThis

--- a/src/visualizations/MapChart.fs
+++ b/src/visualizations/MapChart.fs
@@ -361,16 +361,9 @@ let renderMap (state : State) =
         let maxValue = data |> Seq.map (fun dp -> dp.value) |> Seq.max
 
         let classes =
-            [0..7] |> Seq.map (float) |> Seq.map((*) (float maxValue)) |> Seq.map( (*) 0.125) // 8 class labels  relative to maxValue 
+            let scale = float maxValue * 0.125
+            [0..7] |> Seq.map float |> Seq.map ( (*) scale ) 
 
-        // let maxColor =
-        //     if maxValue = 0. then
-        //         "white" // override for empty map
-        //     else
-        //         match state.ContentType with
-        //         | Deceased -> "#808080"
-        //         | ConfirmedCases -> "#e03000"
-        
         let colorAxis = 
             if maxValue = 0. then 
                 {| dataClassColor = "category"; dataClasses = [| {| from = 0; color = "#ffffcc" |} |] |} |> pojo //override for empty map
@@ -386,7 +379,6 @@ let renderMap (state : State) =
             series = [| series geoJson |]
             legend = {| enabled = false |}
             colorAxis = colorAxis
-            // colorAxis = {| minColor = "white" ; maxColor = maxColor |}
             tooltip =
                 {|
                     formatter = fun () -> tooltipFormatter jsThis

--- a/src/visualizations/MapChart.fs
+++ b/src/visualizations/MapChart.fs
@@ -362,7 +362,7 @@ let renderMap (state : State) =
 
         let classes =
             let scale = float maxValue * 0.125
-            [0..7] |> Seq.map float |> Seq.map ( (*) scale ) 
+            [0..7] |> Seq.map float |> Seq.map ( (*) scale ) //linear spacing between 0 and maxValue
 
         let colorAxis = 
             if maxValue = 0. then 


### PR DESCRIPTION
Implemented a new color scheme for municipalities and regions maps, based on the colors from World map. This is in reference to #582. 

Note:
- The chart showing numbers of deceased in now also in the same color scheme as opposed to greyscale before (revert to greyscale?)

Let me know if I can improve it in any way.

<img width="1000" alt="Screen Shot 2020-10-12 at 10 01 13 AM" src="https://user-images.githubusercontent.com/58387984/95728621-9ecdec80-0c73-11eb-961a-ca476ed63e03.png">
<img width="994" alt="Screen Shot 2020-10-12 at 10 01 43 AM" src="https://user-images.githubusercontent.com/58387984/95728645-a5f4fa80-0c73-11eb-85f5-1777343f3596.png">
<img width="994" alt="Screen Shot 2020-10-12 at 10 03 56 AM" src="https://user-images.githubusercontent.com/58387984/95728650-a7bebe00-0c73-11eb-94f9-f72edd4ba18c.png">
<img width="998" alt="Screen Shot 2020-10-12 at 10 04 16 AM" src="https://user-images.githubusercontent.com/58387984/95728655-a9888180-0c73-11eb-867f-6e2a73499de3.png">


 