### PR TITLE
markdown filter for vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "highcharts-react-official": "^3.0.0",
     "i18next": "^19.7.0",
     "i18next-browser-languagedetector": "^6.0.1",
+    "marked": "^1.2.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "vega": "^5.17.0",

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,4 +1,5 @@
 import Vue from "vue";
+import marked from "marked"
 
 Vue.filter("prefixDiff", function(value) {
   if (value > 0) {
@@ -7,3 +8,12 @@ Vue.filter("prefixDiff", function(value) {
     return `${value}`;
   }
 });
+
+// markdown filter
+// you can use it in Vue template and it will render markdown in user's browser
+// <div v-html="$options.filters.marked($t('charts.ostanizdrav.description'))"></div>
+// You have to use it with v-html directive, because moustache templating (stuf with `{{ ... }}`) will escape generated HTML
+
+Vue.filter("marked", function(input){
+  return marked(input)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7535,6 +7535,11 @@ marked@^0.7.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
   integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
+marked@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.0.tgz#7221ce2395fa6cf6d722e6f2871a32d3513c85ca"
+  integrity sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
# markdown filter

you can use it in Vue template and it will render markdown in user's browser

```<div v-html="$options.filters.marked($t('charts.ostanizdrav.description'))"></div>```

You have to use it with v-html directive, because moustache templating (stuf with `{{ ... }}`) will escape generated HTML