### PR TITLE
Optimize twitter:* meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,6 @@
   <title><%= VUE_APP_TITLE %></title>
   <meta data-vmid="description" name="description" content="<%= VUE_APP_DESC %>" />
   <meta name="twitter:card" content="summary_large_image">
-  <meta data-vmid="twitter:title" name="twitter:title" content="<%= VUE_APP_TITLE %>" />
-  <meta data-vmid="twitter:description" name="twitter:description" content="<%= VUE_APP_DESC %>" />
-  <meta name="twitter:image" content="<%= BASE_URL %>covid-19-logo.png" />
   <meta name="twitter:site" content="@sledilnik" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= BASE_URL %>" />

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <meta data-vmid="twitter:title" name="twitter:title" content="<%= VUE_APP_TITLE %>" />
   <meta data-vmid="twitter:description" name="twitter:description" content="<%= VUE_APP_DESC %>" />
   <meta name="twitter:image" content="<%= BASE_URL %>covid-19-logo.png" />
+  <meta name="twitter:site" content="@sledilnik" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= BASE_URL %>" />
   <meta data-vmid="og:title" property="og:title" content="<%= VUE_APP_TITLE %>" />

--- a/index_caddy.html
+++ b/index_caddy.html
@@ -12,6 +12,7 @@
   <meta data-vmid="twitter:title" name="twitter:title" content="<%= VUE_APP_TITLE %>" />
   <meta data-vmid="twitter:description" name="twitter:description" content="<%= VUE_APP_DESC %>" />
   <meta name="twitter:image" content="https://{{.Host}}/covid-19-logo.png" />
+  <meta name="twitter:site" content="@sledilnik" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= BASE_URL %>" />
   <meta data-vmid="og:title" property="og:title" content="<%= VUE_APP_TITLE %>" />

--- a/index_caddy.html
+++ b/index_caddy.html
@@ -9,9 +9,6 @@
   <title><%= VUE_APP_TITLE %></title>
   <meta data-vmid="description" name="description" content="<%= VUE_APP_DESC %>" />
   <meta name="twitter:card" content="summary_large_image">
-  <meta data-vmid="twitter:title" name="twitter:title" content="<%= VUE_APP_TITLE %>" />
-  <meta data-vmid="twitter:description" name="twitter:description" content="<%= VUE_APP_DESC %>" />
-  <meta name="twitter:image" content="https://{{.Host}}/covid-19-logo.png" />
   <meta name="twitter:site" content="@sledilnik" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= BASE_URL %>" />

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,8 +31,6 @@ export default {
       title: this.$t('meta.title'),
       meta: [
         { vmid: 'description', name: 'description', content: this.$t('meta.description') },
-        { vmid: 'twitter:title', name: 'twitter:title', content: this.$t('meta.title') },
-        { vmid: 'twitter:description', name: 'twitter:description', content: this.$t('meta.description') },
         { vmid: 'og:title', property: 'og:title', content: this.$t('meta.title') },
         { vmid: 'og:description', property: 'og:description', content: this.$t('meta.description') },
       ],


### PR DESCRIPTION
1) Added `twitter:site` to enable basic analytics - see https://analytics.twitter.com
2) Removed redundant `twitter:*` tags as twitter will fallback to OpenGraph `og:*` tags - see https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started