### PR TITLE
Added Facebook app_id meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <meta data-vmid="description" name="description" content="<%= VUE_APP_DESC %>" />
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@sledilnik" />
+  <meta property="fb:app_id" content="112977840347535" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= BASE_URL %>" />
   <meta data-vmid="og:title" property="og:title" content="<%= VUE_APP_TITLE %>" />

--- a/index_caddy.html
+++ b/index_caddy.html
@@ -10,6 +10,7 @@
   <meta data-vmid="description" name="description" content="<%= VUE_APP_DESC %>" />
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@sledilnik" />
+  <meta property="fb:app_id" content="112977840347535" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= BASE_URL %>" />
   <meta data-vmid="og:title" property="og:title" content="<%= VUE_APP_TITLE %>" />


### PR DESCRIPTION
This should link the page and its shares to the https://www.facebook.com/COVID19Sledilnik
and fix the
>Warnings That Should Be Fixed
Missing Properties
The following required properties are missing: fb:app_id

on eg
https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fcovid-19.sledilnik.org%2Fsl%2Fostanizdrav