### PR TITLE
Infocard: Highlight in red outdated (>36h) timestamps

### DIFF
--- a/src/components/cards/InfoCard.vue
+++ b/src/components/cards/InfoCard.vue
@@ -47,7 +47,7 @@
           </span>
         </div>
       </div>
-      <div class="data-time">
+      <div class="data-time" :class="(new Date()-1000*3600*36)>renderValues.lastDay.displayDate? 'outdated':''">
         {{
           $t('infocard.lastUpdated', {
             date: new Date(renderValues.lastDay.displayDate),
@@ -365,5 +365,9 @@ export default {
   font-size: 12px;
   color: #a0a0a0;
   margin-top: auto;
+
+  &.outdated {
+    color: #bf5747;
+  }
 }
 </style>


### PR DESCRIPTION
Eg:
![image](https://user-images.githubusercontent.com/319826/101182881-fde62700-364e-11eb-9d91-8083b956ca5b.png)
