### PR TITLE
refactor: Use a common pattern for enums in used in visualization state

### DIFF
--- a/src/visualizations/AgeGroupsChart.fs
+++ b/src/visualizations/AgeGroupsChart.fs
@@ -11,6 +11,8 @@ open Types
 open Highcharts
 open System
 
+let chartText = I18N.chartText "ageGroups"
+
 type ScaleType = Absolute | Relative
 
 type ChartMode =
@@ -20,8 +22,25 @@ type ChartMode =
     | DeathsPerPopulation
     | DeathsPerInfections
 
-    static member ScaleType mode =
-        match mode with
+    static member All =
+        [ AbsoluteInfections
+          AbsoluteDeaths
+          InfectionsPerPopulation
+          DeathsPerPopulation
+          DeathsPerInfections ]
+
+    static member Default = AbsoluteInfections
+
+    member this.GetName: string =
+        match this with
+        | AbsoluteInfections -> chartText "confirmedCases"
+        | AbsoluteDeaths -> chartText "deceased"
+        | InfectionsPerPopulation -> chartText "confirmedCases"
+        | DeathsPerPopulation -> chartText "deceased"
+        | DeathsPerInfections -> chartText "deceasedPerConfirmedCases"
+
+    member this.ScaleType =
+        match this with
         | AbsoluteInfections -> Absolute
         | AbsoluteDeaths -> Absolute
         | InfectionsPerPopulation -> Relative
@@ -44,7 +63,6 @@ let LabelMale = "Moški"
 [<Literal>]
 let LabelFemale = "Ženske"
 
-let chartText = I18N.chartText "ageGroups"
 
 let populationOf sexLabel ageGroupLabel =
     let parseAgeGroupLabel (label: string): AgeGroupKey =
@@ -295,19 +313,12 @@ let renderChartCategorySelector
         Utils.classes [
             (true, "btn btn-sm metric-selector")
             (isActive, "metric-selector--selected") ]
-        prop.text (
-            match chartModeToRender with
-            | AbsoluteInfections        -> chartText "confirmedCases"
-            | AbsoluteDeaths            -> chartText "deceased"
-            | InfectionsPerPopulation   -> chartText "confirmedCases"
-            | DeathsPerPopulation       -> chartText "deceased"
-            | DeathsPerInfections       -> chartText "deceasedPerConfirmedCases"
-            )
+        prop.text ( chartModeToRender.GetName )
     ]
 
 let renderChartCategorySelectors activeChartMode dispatch =
-    let categoriesForChartMode chartMode =
-        match ChartMode.ScaleType chartMode with
+    let categoriesForChartMode (chartMode: ChartMode) =
+        match chartMode.ScaleType with
         | Absolute -> [ AbsoluteInfections; AbsoluteDeaths ]
         | Relative ->
             [
@@ -327,7 +338,7 @@ let renderChartOptions
     (state : State) (latestDate: DateTime) (chartData: AgesChartData) =
 
     let valuesLabelFormatter (value: float) =
-        match ChartMode.ScaleType state.ChartMode with
+        match state.ChartMode.ScaleType with
         | Absolute -> (I18N.NumberFormat.formatNumber (abs value))
         | Relative -> Utils.percentWith3DecimalSignFormatter value
 
@@ -353,7 +364,7 @@ let renderChartOptions
                  {| formatter = fun () -> valuesLabelFormatter jsThis?value |}
                // allowDecimals needs to be enabled because the values can be
                // be below 1, otherwise it won't auto-scale to below 1.
-               allowDecimals = ChartMode.ScaleType state.ChartMode = Relative
+               allowDecimals = state.ChartMode.ScaleType = Relative
             |}
         plotOptions = pojo
             {| series = pojo
@@ -447,7 +458,7 @@ let renderChartOptions
     |}
 
 let init (data : StatsData) : State * Cmd<Msg> =
-    { ChartMode = AbsoluteInfections; Data = data }, Cmd.none
+    { ChartMode = ChartMode.Default; Data = data }, Cmd.none
 
 let update (msg: Msg) (state: State) : State * Cmd<Msg> =
     match msg with
@@ -480,8 +491,7 @@ let renderChartContainer state =
     ]
 
 let render (state : State) dispatch =
-    let activeScaleType = ChartMode.ScaleType state.ChartMode
-
+    let activeScaleType = state.ChartMode.ScaleType
     Html.div [
         Utils.renderChartTopControlRight
             (renderScaleTypeSelectors activeScaleType (ScaleTypeChanged >> dispatch))

--- a/src/visualizations/AgeGroupsTimelineViz/Rendering.fs
+++ b/src/visualizations/AgeGroupsTimelineViz/Rendering.fs
@@ -29,7 +29,7 @@ type Msg =
 let init data : State * Cmd<Msg> =
     let state = {
         Data = data
-        Metrics = availableDisplayMetrics.[0]
+        Metrics = DisplayMetrics.Default
         RangeSelectionButtonIndex = 0
     }
     state, Cmd.none
@@ -118,7 +118,7 @@ let renderMetricsSelectors activeMetrics dispatch =
 
     Html.div [
         prop.className "metrics-selectors"
-        availableDisplayMetrics
+        DisplayMetrics.All
         |> Array.map renderSelector
         |> prop.children
     ]

--- a/src/visualizations/AgeGroupsTimelineViz/Synthesis.fs
+++ b/src/visualizations/AgeGroupsTimelineViz/Synthesis.fs
@@ -11,18 +11,18 @@ type DisplayMetrics = {
     Id: string
     ValueCalculation: ValueCalculationFormula
     ChartType: ChartType
-}
-
-let availableDisplayMetrics = [|
-    { Id = "newCases"; ValueCalculation = Daily
-      ChartType = StackedBarNormal }
-    { Id = "newCasesRelative"; ValueCalculation = Daily
-      ChartType = StackedBarPercent }
-    { Id = "activeCases"; ValueCalculation = Active
-      ChartType = StackedBarNormal }
-    { Id = "activeCasesRelative"; ValueCalculation = Active
-      ChartType = StackedBarPercent }
-|]
+} with
+    static member All = [|
+        { Id = "newCases"; ValueCalculation = Daily
+          ChartType = StackedBarNormal }
+        { Id = "newCasesRelative"; ValueCalculation = Daily
+          ChartType = StackedBarPercent }
+        { Id = "activeCases"; ValueCalculation = Active
+          ChartType = StackedBarNormal }
+        { Id = "activeCasesRelative"; ValueCalculation = Active
+          ChartType = StackedBarPercent }
+    |]
+    static member Default = DisplayMetrics.All.[0]
 
 let tooltipFormatter jsThis =
     let points: obj[] = jsThis?points

--- a/src/visualizations/CasesChart.fs
+++ b/src/visualizations/CasesChart.fs
@@ -13,13 +13,9 @@ open Browser
 open Types
 open Highcharts
 
-type DisplayType =
-    | MultiChart
-
 type State = {
     data: StatsData
     PatientsData : PatientsStats []
-    displayType: DisplayType
     RangeSelectionButtonIndex: int
     Error : string option
 }
@@ -27,7 +23,6 @@ type State = {
 type Msg =
     | ConsumePatientsData of Result<PatientsStats [], string>
     | ConsumeServerError of exn
-    | ChangeDisplayType of DisplayType
     | RangeSelectionChanged of int
 
 type Series =
@@ -40,12 +35,12 @@ type Series =
     | Icu
     | Critical
 
-module Series =
-    let all =
+    static member All =
         [ Active; InHospital; Icu; Critical; Recovered
           DeceasedOther; DeceasedInHospitals; DeceasedInIcu ]
 
-    let getSeriesInfo = function
+    member this.GetSeriesInfo =
+        match this with
         | DeceasedInIcu        -> true,  "#6d5b80",   "deceased-icu"
         | DeceasedInHospitals  -> true,  "#8c71a8",   "deceased-hospital"
         | DeceasedOther        -> true,  "#c59eef",   "deceased-rest"
@@ -59,7 +54,6 @@ let init data : State * Cmd<Msg> =
     let state = {
         data = data
         PatientsData = [||]
-        displayType = MultiChart
         RangeSelectionButtonIndex = 0
         Error = None
     }
@@ -77,8 +71,6 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
         { state with Error = Some err }, Cmd.none
     | ConsumeServerError ex ->
         { state with Error = Some ex.Message }, Cmd.none
-    | ChangeDisplayType rt ->
-        { state with displayType=rt }, Cmd.none
     | RangeSelectionChanged buttonIndex ->
         { state with RangeSelectionButtonIndex = buttonIndex }, Cmd.none
 
@@ -174,7 +166,7 @@ let renderChartOptions (state : State) dispatch =
             |> Seq.toList
             |> List.sortBy (fun (date, _, _) -> date)
 
-        let visible, color, seriesId = Series.getSeriesInfo series
+        let visible, color, seriesId = series.GetSeriesInfo
         {|
             ``type`` = "column"
             visible = visible
@@ -198,7 +190,7 @@ let renderChartOptions (state : State) dispatch =
         |> pojo
 
     let allSeries = [|
-        for series in Series.all do
+        for series in Series.All do
             yield renderSeries series
     |]
 

--- a/src/visualizations/EuropeMapChart.fs
+++ b/src/visualizations/EuropeMapChart.fs
@@ -46,7 +46,9 @@ type ChartType =
     | Restrictions
     | WeeklyIncrease
 
-    override this.ToString() =
+    static member All = [ TwoWeekIncidence; WeeklyIncrease; Restrictions ]
+    static member Default = TwoWeekIncidence
+    member this.GetName =
         match this with
         | TwoWeekIncidence -> chartText "twoWeekIncidence"
         | Restrictions -> chartText "restrictions"
@@ -803,17 +805,12 @@ let renderChartTypeSelectors (activeChartType: ChartType) dispatch =
             Utils.classes
                 [(true, "chart-display-property-selector__item")
                  (active, "selected")]
-            prop.text (chartSelector.ToString())
+            prop.text chartSelector.GetName
         ]
 
     Html.div
         [ prop.className "chart-display-property-selector"
-          prop.children
-              [
-                renderChartSelector TwoWeekIncidence
-                renderChartSelector WeeklyIncrease
-                renderChartSelector Restrictions
-              ]
+          prop.children (ChartType.All |> Seq.map renderChartSelector)
         ]
 
 

--- a/src/visualizations/ExcessDeathsChart/Main.fs
+++ b/src/visualizations/ExcessDeathsChart/Main.fs
@@ -9,7 +9,7 @@ open Types
 let init statsData =
     { StatsData = statsData
       WeeklyDeathsData = Loading
-      DisplayType = AbsoluteDeaths
+      DisplayType = DisplayType.Default
     }
 
 let update state msg =
@@ -39,14 +39,14 @@ let update state msg =
 
 let renderDisplayTypeSelectors state dispatch =
     let selectors =
-        DisplayType.available
+        DisplayType.All
         |> List.map (fun dt ->
             Html.div [
                 prop.onClick (fun _ -> DisplayTypeChanged dt |> dispatch)
                 Utils.classes
                     [(true, "chart-display-property-selector__item")
                      (state.DisplayType = dt, "selected")]
-                prop.text (DisplayType.getName dt) ] )
+                prop.text dt.GetName ] )
 
     Html.div [
         prop.className "chart-display-property-selector"

--- a/src/visualizations/ExcessDeathsChart/Types.fs
+++ b/src/visualizations/ExcessDeathsChart/Types.fs
@@ -20,9 +20,12 @@ type DisplayType =
     | AbsoluteDeaths
     | ExcessDeaths
 with
-    static member available = [ AbsoluteDeaths ; ExcessDeaths ]
+    static member All = [ AbsoluteDeaths ; ExcessDeaths ]
 
-    static member getName = function
+    static member Default = AbsoluteDeaths
+
+    member this.GetName =
+        match this with
         | AbsoluteDeaths -> I18N.t "charts.excessDeaths.absolute.title"
         | ExcessDeaths -> I18N.t "charts.excessDeaths.excess.title"
 

--- a/src/visualizations/InfectionsChart.fs
+++ b/src/visualizations/InfectionsChart.fs
@@ -35,7 +35,7 @@ type DayValueFloat = JsTimestamp*float
 type ShowAllOrOthers = ShowAllConfirmed | ShowOthers
 
 module Metrics  =
-    let all = [
+    let All = [
         { Metric=AllConfirmed;      Color="#bda506"; Id="allConfirmed" }
         { Metric=OtherPeople;       Color="#FFDBA3"; Id="otherPersons" }
         { Metric=HospitalStaff;     Color="#73ccd5"; Id="hcStaff" }
@@ -45,7 +45,7 @@ module Metrics  =
 
     let metricsToDisplay filter =
         let without metricType =
-            all |> List.filter (fun metric -> metric.Metric <> metricType)
+            All |> List.filter (fun metric -> metric.Metric <> metricType)
 
         match filter with
         | ShowAllConfirmed -> without OtherPeople
@@ -59,31 +59,32 @@ type DisplayType = {
     ShowAllOrOthers: ShowAllOrOthers
     ChartType: ChartType
     ShowPhases: bool
-}
+} with
+    static member All =
+        [|
+            {   Id = "averageByDay"
+                ValueTypes = MovingAverages
+                ShowAllOrOthers = ShowAllConfirmed
+                ChartType = SplineChart
+                ShowPhases = true
+            }
+            {   Id = "all";
+                ValueTypes = RunningTotals
+                ShowAllOrOthers = ShowOthers
+                ChartType = StackedBarNormal
+                ShowPhases = false
+            }
+            {   Id = "relative";
+                ValueTypes = RunningTotals
+                ShowAllOrOthers = ShowOthers
+                ChartType = StackedBarPercent
+                ShowPhases = false
+            }
+        |]
+    static member Default = DisplayType.All.[0]
 
 [<Literal>]
 let DaysOfMovingAverage = 7
-
-let availableDisplayTypes: DisplayType array = [|
-    {   Id = "averageByDay"
-        ValueTypes = MovingAverages
-        ShowAllOrOthers = ShowAllConfirmed
-        ChartType = SplineChart
-        ShowPhases = true
-    }
-    {   Id = "all";
-        ValueTypes = RunningTotals
-        ShowAllOrOthers = ShowOthers
-        ChartType = StackedBarNormal
-        ShowPhases = false
-    }
-    {   Id = "relative";
-        ValueTypes = RunningTotals
-        ShowAllOrOthers = ShowOthers
-        ChartType = StackedBarPercent
-        ShowPhases = false
-    }
-|]
 
 type State = {
     DisplayType : DisplayType
@@ -98,7 +99,7 @@ type Msg =
 let init data : State * Cmd<Msg> =
     let state = {
         Data = data
-        DisplayType = availableDisplayTypes.[0]
+        DisplayType = DisplayType.Default
         RangeSelectionButtonIndex = 0
     }
     state, Cmd.none
@@ -287,7 +288,7 @@ let renderDisplaySelectors activeDisplayType dispatch =
 
     Html.div [
         prop.className "metrics-selectors"
-        availableDisplayTypes
+        DisplayType.All
         |> Array.map renderSelector
         |> prop.children
     ]

--- a/src/visualizations/MetricsComparisonChart.fs
+++ b/src/visualizations/MetricsComparisonChart.fs
@@ -30,12 +30,12 @@ type FullMetricType = {
         | Today, false -> chartText "showToday"
         | Today, true -> chartText "show7DaysAverage"
         | ToDate, _ -> chartText "showToDate"
-
-let availableMetricTypes =
-    [ { MetricType = Active; IsAveraged = false }
-      { MetricType = Today; IsAveraged = false }
-      { MetricType = ToDate; IsAveraged = false }
-      { MetricType = Today; IsAveraged = true } ]
+    static member All =
+        [ { MetricType = Active; IsAveraged = false }
+          { MetricType = Today; IsAveraged = false }
+          { MetricType = ToDate; IsAveraged = false }
+          { MetricType = Today; IsAveraged = true } ]
+    static member Default = { MetricType = Active; IsAveraged = false }
 
 type Metric =
     | PerformedTestsToday
@@ -126,7 +126,7 @@ let init data : State * Cmd<Msg> =
     let cmd = Cmd.OfAsync.either getOrFetch () ConsumePatientsData ConsumeServerError
     let state = {
         ScaleType = Linear
-        MetricType = { MetricType = Active; IsAveraged = false }
+        MetricType = FullMetricType.Default
         Metrics = Metrics.initial
         StatsData = data
         PatientsData = [||]
@@ -336,7 +336,7 @@ let renderMetricTypeSelectors (activeMetricType: FullMetricType) dispatch =
         ]
 
     let metricTypesSelectors =
-        availableMetricTypes
+        FullMetricType.All
         |> List.map renderMetricTypeSelector
 
     Html.div [

--- a/src/visualizations/MetricsCorrelationViz/Rendering.fs
+++ b/src/visualizations/MetricsCorrelationViz/Rendering.fs
@@ -45,23 +45,23 @@ type DisplayType = {
     ValueTypes: ValueTypes
     ChartType: ChartType
     ShowPhases: bool
-}
+} with
+    static member All = [|
+        {   Id = "averageByDay"
+            ValueTypes = MovingAverages
+            ChartType = SplineChart
+            ShowPhases = true
+        }
+        {   Id = "all";
+            ValueTypes = RunningTotals
+            ChartType = SplineChart
+            ShowPhases = true
+        }
+    |]
+    static member Default = DisplayType.All.[0]
 
 [<Literal>]
 let DaysOfMovingAverage = 7
-
-let availableDisplayTypes: DisplayType array = [|
-    {   Id = "averageByDay"
-        ValueTypes = MovingAverages
-        ChartType = SplineChart
-        ShowPhases = true
-    }
-    {   Id = "all";
-        ValueTypes = RunningTotals
-        ChartType = SplineChart
-        ShowPhases = true
-    }
-|]
 
 type State = {
     DisplayType : DisplayType
@@ -76,7 +76,7 @@ type Msg =
 let init data : State * Cmd<Msg> =
     let state = {
         Data = data
-        DisplayType = availableDisplayTypes.[0]
+        DisplayType = DisplayType.Default
         RangeSelectionButtonIndex = 1
     }
     state, Cmd.none
@@ -300,7 +300,7 @@ let renderDisplaySelectors activeDisplayType dispatch =
 
     Html.div [
         prop.className "metrics-selectors"
-        availableDisplayTypes
+        DisplayType.All
         |> Array.map renderSelector
         |> prop.children
     ]

--- a/src/visualizations/PatientsChart.fs
+++ b/src/visualizations/PatientsChart.fs
@@ -17,15 +17,43 @@ type HospitalType =
     | CovidHospitals
     | CareHospitals
 
+    static member All = [ CovidHospitals; CareHospitals ]
+
 type Breakdown =
     | ByHospital
     | AllHospitals
     | Facility of string
   with
-    static member getName = function
+    static member All state = seq {
+        yield ByHospital
+        yield AllHospitals
+        for fcode in state.AllFacilities do
+            yield Facility fcode
+    }
+    static member Default = AllHospitals
+    member this.GetName =
+        match this with
         | ByHospital -> I18N.t "charts.patients.byHospital"
         | AllHospitals -> I18N.t "charts.patients.allHospitals"
         | Facility facility -> Utils.Dictionaries.GetFacilityName(facility)
+
+and State = {
+    PatientsData : PatientsStats []
+    Error : string option
+    AllFacilities : string list
+    HTypeToDisplay : HospitalType
+    Breakdown : Breakdown
+    RangeSelectionButtonIndex: int
+  } with
+    static member initial hTypeToDisplay =
+        {
+            PatientsData = [||]
+            Error = None
+            AllFacilities = []
+            HTypeToDisplay = hTypeToDisplay
+            Breakdown = Breakdown.Default
+            RangeSelectionButtonIndex = 0
+        }
 
 type Series =
     | InHospital
@@ -63,30 +91,7 @@ module Series =
         | CareOut               -> "#8cd4b2", "discharged"
         | CareDeceased          -> "#a483c7", "deceased"
 
-type State = {
-    PatientsData : PatientsStats []
-    Error : string option
-    AllFacilities : string list
-    HTypeToDisplay : HospitalType
-    Breakdown : Breakdown
-    RangeSelectionButtonIndex: int
-  } with
-    static member initial hTypeToDisplay =
-        {
-            PatientsData = [||]
-            Error = None
-            AllFacilities = []
-            HTypeToDisplay = hTypeToDisplay
-            Breakdown = AllHospitals
-            RangeSelectionButtonIndex = 0
-        }
 
-let getAllBreakdowns state = seq {
-        yield ByHospital
-        yield AllHospitals
-        for fcode in state.AllFacilities do
-            yield Facility fcode
-    }
 
 type Msg =
     | ConsumePatientsData of Result<PatientsStats [], string>
@@ -348,14 +353,14 @@ let renderBreakdownSelector state breakdown dispatch =
         Utils.classes
             [(true, "btn btn-sm metric-selector")
              (state.Breakdown = breakdown, "metric-selector--selected") ]
-        prop.text (breakdown |> Breakdown.getName)
+        prop.text breakdown.GetName
     ]
 
 let renderBreakdownSelectors state dispatch =
     Html.div [
         prop.className "metrics-selectors"
         prop.children (
-            getAllBreakdowns state
+            Breakdown.All state
             |> Seq.map (fun breakdown -> renderBreakdownSelector state breakdown dispatch) ) ]
 
 let render (state : State) dispatch =

--- a/src/visualizations/PhaseDiagram/Chart.fs
+++ b/src/visualizations/PhaseDiagram/Chart.fs
@@ -38,14 +38,9 @@ let update (msg: Msg) (state: State) : State * Cmd<Msg> =
             DisplayData = displayData
             Day = displayData.Length - 1 }, Cmd.none
     | MetricSelected metric ->
-        let newState =
-            match metric with
-            | CasesMetric -> { state with Metric = Cases }
-            | HospitalizedMetric -> { state with Metric = Hospitalized }
-            | DeceasedMetric -> { state with Metric = Deceased }
-            | UnknownMetric -> state
-        let newDisplayData = displayData newState.Metric state.DiagramKind state.StatsData
-        { newState with
+        let newDisplayData = displayData metric state.DiagramKind state.StatsData
+        { state with
+            Metric = metric
             DisplayData = newDisplayData
             Day = newDisplayData.Length - 1 }, Cmd.none
 
@@ -87,12 +82,12 @@ let totalVsWeekChartOptions state =
 
         series = [|
             {| data = data
-               color = state.Metric.Color.Light
+               color = state.Metric.GetColor.Light
                marker = pojo {| symbol = "circle" ; radius = 2 |}
                states = pojo {| hover = pojo {| lineWidth = 0 |} |}
             |} |> pojo
             {| data = [| data.[state.Day] |]
-               color = state.Metric.Color.Dark
+               color = state.Metric.GetColor.Dark
                marker = pojo {| symbol = "circle" ; radius = 8 |}
                states = pojo {| hover = pojo {| lineWidth = 0 |} |}
             |} |> pojo
@@ -130,12 +125,12 @@ let weekVsWeekBeforeOptions state =
 
         series = [|
             {| data = data
-               color = state.Metric.Color.Light
+               color = state.Metric.GetColor.Light
                marker = pojo {| symbol = "circle" ; radius = 3 |}
                states = pojo {| hover = pojo {| lineWidth = 0 |} |}
             |} |> pojo
             {| data = [| data.[state.Day] |]
-               color = state.Metric.Color.Dark
+               color = state.Metric.GetColor.Dark
                marker = pojo {| symbol = "circle" ; radius = 8 |}
                states = pojo {| hover = pojo {| lineWidth = 0 |} |}
             |} |> pojo
@@ -143,12 +138,11 @@ let weekVsWeekBeforeOptions state =
     |} |> pojo
 
 let renderMetricSelector (selected : Metric) dispatch =
-    let options =
-        Metric.AllMetrics
-        |> List.map (fun metric ->
+    let metrics = Metric.All |> List.map (fun metric -> (metric.ToString(), metric))
+    let options = metrics |> List.map (fun (metricString, metric) ->
             Html.option [
-                prop.text metric.Name
-                prop.value (metric.ToString())
+                prop.text metric.GetName
+                prop.value (metricString)
             ]
         )
 
@@ -156,7 +150,7 @@ let renderMetricSelector (selected : Metric) dispatch =
         prop.value (selected.ToString())
         prop.className "form-control form-control-sm filters__type"
         prop.children options
-        prop.onChange (MetricSelected >> dispatch)
+        prop.onChange ( (fun ct -> Map.find ct (metrics |> Map.ofList)) >> MetricSelected >> dispatch)
     ]
 
 let renderDiagramKindSelectors (selected : DiagramKind) dispatch =
@@ -166,7 +160,7 @@ let renderDiagramKindSelectors (selected : DiagramKind) dispatch =
             Utils.classes
                 [(true, "chart-display-property-selector__item")
                  (diagramKind = selected, "selected") ]
-            prop.text diagramKind.Name
+            prop.text diagramKind.GetName
         ]
 
     Html.div [

--- a/src/visualizations/PhaseDiagram/Types.fs
+++ b/src/visualizations/PhaseDiagram/Types.fs
@@ -12,7 +12,7 @@ type DiagramKind =
 
     with
 
-    member this.Name =
+    member this.GetName =
         match this with
         | TotalVsWeek -> i18n "totalVsWeek.name"
         | WeekVsWeekBefore -> i18n "weekVsWeekBefore.name"
@@ -31,13 +31,13 @@ type Metric =
 
     with
 
-    member this.Name =
+    member this.GetName =
         match this with
         | Cases -> i18n "cases"
         | Hospitalized -> i18n "hospitalized"
         | Deceased -> i18n "deceased"
 
-    member this.Color =
+    member this.GetColor =
         match this with
         | Cases ->
             { Dark = "#dba51d"
@@ -49,14 +49,8 @@ type Metric =
             { Dark = "#000000"
               Light = "#999999" }
 
-    static member AllMetrics =
+    static member All =
         [ Cases ; Hospitalized ; Deceased ]
-
-let (|CasesMetric|HospitalizedMetric|DeceasedMetric|UnknownMetric|) str =
-    if str = Metric.Cases.ToString() then CasesMetric
-    elif str = Metric.Hospitalized.ToString() then HospitalizedMetric
-    elif str = Metric.Deceased.ToString() then DeceasedMetric
-    else UnknownMetric
 
 type DisplayData = {
     x : int
@@ -74,5 +68,5 @@ type State = {
 
 type Msg =
     | DiagramKindSelected of DiagramKind
-    | MetricSelected of string
+    | MetricSelected of Metric
     | DayChanged of int

--- a/src/visualizations/RegionsChartViz/Analysis.fs
+++ b/src/visualizations/RegionsChartViz/Analysis.fs
@@ -9,7 +9,8 @@ type MetricType =
     | NewCases7Days
     | Deceased
   with
-    static member getName = function
+    static member Default = MetricType.ActiveCases
+    static member GetName = function
         | ActiveCases -> I18N.chartText "regions" "activeCases"
         | ConfirmedCases -> I18N.chartText "regions" "confirmedCases"
         | NewCases7Days -> I18N.chartText "regions" "newCases7Days"

--- a/src/visualizations/RegionsChartViz/Rendering.fs
+++ b/src/visualizations/RegionsChartViz/Rendering.fs
@@ -67,7 +67,7 @@ let init (config: RegionsChartConfig) (data : RegionsData)
               Color = color
               Visible = true } )
 
-    { ScaleType = Linear; MetricType = ActiveCases
+    { ScaleType = Linear; MetricType = MetricType.Default
       ChartConfig = config
       RegionsData = data
       Regions = regionsByTotalCases
@@ -251,7 +251,7 @@ let renderMetricTypeSelectors (activeMetricType: MetricType) dispatch =
             Utils.classes
                 [(true, "chart-display-property-selector__item")
                  (active, "selected") ]
-            prop.text (typeSelector |> MetricType.getName)
+            prop.text (typeSelector |> MetricType.GetName)
         ]
 
     let metricTypesSelectors =

--- a/src/visualizations/SourcesChart.fs
+++ b/src/visualizations/SourcesChart.fs
@@ -47,8 +47,20 @@ type DisplayType =
     | BySourceCountry
     | BySourceCountryRelative
   with
-    static member all = [ ByLocation; ByLocationRelative; BySource; BySourceRelative; BySourceCountry; BySourceCountryRelative; Quarantine; QuarantineRelative ]
-    static member getName = function
+    static member All =
+        [ ByLocation
+          ByLocationRelative
+          BySource
+          BySourceRelative
+          BySourceCountry
+          BySourceCountryRelative
+          Quarantine
+          QuarantineRelative ]
+
+    static member Default = ByLocation
+
+    member this.GetName =
+        match this with
         | Quarantine                -> chartText "quarantine"
         | QuarantineRelative        -> chartText "quarantineRelative"
         | ByLocation                -> chartText "byLocation"
@@ -72,7 +84,7 @@ type Msg =
 
 let init data: State * Cmd<Msg> =
     let state =
-        { displayType = ByLocation
+        { displayType = DisplayType.Default
           data = data
           RangeSelectionButtonIndex = 0 }
 
@@ -97,14 +109,14 @@ let renderDisplaySelector state dt dispatch =
         Utils.classes
             [(true, "btn btn-sm metric-selector")
              (state.displayType = dt, "metric-selector--selected") ]
-        prop.text (dt |> DisplayType.getName)
+        prop.text dt.GetName
     ]
 
 let renderDisplaySelectors state dispatch =
     Html.div [
         prop.className "metrics-selectors"
         prop.children (
-            DisplayType.all
+            DisplayType.All
             |> List.map (fun dt -> renderDisplaySelector state dt dispatch) ) ]
 
 type Series =
@@ -136,7 +148,7 @@ module Series =
     let quarantineRelative = [  ConfirmedCases; ConfirmedFromQuarantine ]
     let bySource = [ImportedCases; ImportRelatedCases; LocalSource; SourceUnknown; ]
     let byLocation = [Family; Work; School; Hospital; OtherHealthcare; RetirementHome; Prison; Transport; Shop; Restaurant; Sport; GatheringPrivate; GatheringOrganized; LocationOther; LocationUnknown ]
-    
+
     let getSeriesInfo =
         function
         | SentToQuarantine ->  "#cccccc", "sentToQuarantine", 0

--- a/src/visualizations/SpreadChart.fs
+++ b/src/visualizations/SpreadChart.fs
@@ -15,8 +15,8 @@ type Scale =
     | Percentage
     | DoublingRate
   with
-    static member all = [ Absolute; Percentage; DoublingRate ]
-    static member getName = function
+    static member All = [ Absolute; Percentage; DoublingRate ]
+    static member GetName = function
         | Absolute      -> I18N.t "charts.spread.absolute"
         | Percentage    -> I18N.t "charts.spread.percentage"
         | DoublingRate  -> I18N.t "charts.spread.doublingRate"
@@ -25,9 +25,10 @@ type Page =
     | Chart of Scale
     | Explainer
   with
-    static member all = (Scale.all |> List.map Chart) @ [ Explainer ]
-    static member getName = function
-        | Chart scale   -> Scale.getName scale
+    static member All = (Scale.All |> List.map Chart) @ [ Explainer ]
+    static member Default = Chart Absolute
+    static member GetName = function
+        | Chart scale   -> Scale.GetName scale
         | Explainer     -> I18N.t "charts.spread.explainer"
 
 type State = {
@@ -42,7 +43,7 @@ type Msg =
 
 let init data : State * Cmd<Msg> =
     let state = {
-        page = Chart Absolute
+        page = Page.Default
         data = data
         RangeSelectionButtonIndex = 0
     }
@@ -276,12 +277,12 @@ let renderScaleSelectors state dispatch =
                 [(true, "btn  btn-sm metric-selector")
                  (isActive, "metric-selector--selected")]
             prop.style style
-            prop.text (page |> Page.getName) ]
+            prop.text (page |> Page.GetName) ]
 
     Html.div [
         prop.className "metrics-selectors"
         prop.children [
-            for page in Page.all do
+            for page in Page.All do
                 yield renderScaleSelector page dispatch
         ]
     ]

--- a/src/visualizations/TestsChart.fs
+++ b/src/visualizations/TestsChart.fs
@@ -18,6 +18,17 @@ type DisplayType =
     | ByLab
     | ByLabPercent
     | Lab of string
+    static member All state =
+        seq {
+            for typ in [ "hagt"; "regular"; "ns-apr20" ] do
+                yield Data typ
+            yield TotalPCR
+            yield ByLab
+            yield ByLabPercent
+            for lab in state.AllLabs do
+                yield Lab lab
+        }
+    static member Default = Data "regular"
     static member GetName =
         function
         | TotalPCR -> I18N.t "charts.tests.totalPCR"
@@ -26,23 +37,13 @@ type DisplayType =
         | ByLabPercent -> I18N.t "charts.tests.byLabPercent"
         | Lab facility -> Utils.Dictionaries.GetFacilityName(facility)
 
-type State =
+and State =
     { LabData: LabTestsStats array
       Error: string option
       AllLabs: string list
       DisplayType: DisplayType
       RangeSelectionButtonIndex: int }
 
-let GetAllDisplayTypes state =
-    seq {
-        for typ in [ "hagt"; "regular"; "ns-apr20" ] do
-            yield Data typ
-        yield TotalPCR
-        yield ByLab
-        yield ByLabPercent
-        for lab in state.AllLabs do
-            yield Lab lab
-    }
 
 type Msg =
     | ConsumeLabTestsData of Result<LabTestsStats array, string>
@@ -58,7 +59,7 @@ let init: State * Cmd<Msg> =
         { LabData = [||]
           Error = None
           AllLabs = []
-          DisplayType = Data "regular"
+          DisplayType = DisplayType.Default
           RangeSelectionButtonIndex = 0 }
 
     state, cmd
@@ -350,7 +351,7 @@ let renderSelector state (dt: DisplayType) dispatch =
 let renderDisplaySelectors state dispatch =
     Html.div [ prop.className "metrics-selectors"
                prop.children
-                   (GetAllDisplayTypes state
+                   (DisplayType.All state
                     |> Seq.map (fun dt -> renderSelector state dt dispatch)) ]
 
 let render (state: State) dispatch =


### PR DESCRIPTION
This is a unification of pattern used accross visualizations.
Common ones are DisplayType and Metric. They usually have some
default value and a list of available choices for displaying a selector.

 - Now they all have static members GetName, Default and All
 - Member names are in PascalCase, as per
   https://docs.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting#naming-conventions
 - Removed `displayType` from `CasesChart.fs`. There was only one choice. Probably a historic artifact.