### PR TITLE
Upgrade vue-stripe from 4.0.3 to 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/vue-fontawesome": "^2.0.0",
     "@panter/vue-i18next": "^0.15.2",
-    "@vue-stripe/vue-stripe": "^4.0.0-beta.0",
+    "@vue-stripe/vue-stripe": "^4.1.1",
     "axios": "^0.21.1",
     "axios-cache-adapter": "^2.5.0",
     "axios-etag-cache": "^1.0.5",

--- a/src/pages/DonationPage.vue
+++ b/src/pages/DonationPage.vue
@@ -34,7 +34,7 @@
               :pk="publishableKey"
               :success-url="successURL+'&type=monthly'"
               :cancel-url="cancelURL"
-              :locale="stripeLanguage"
+              :locale="language"
               @loading="v => loading = v"
             />
             <span v-for="(item) in stripeSubscriptions" :key="item.price">
@@ -150,7 +150,7 @@
               :pk="publishableKey"
               :success-url="successURL+'&type=onetime'"
               :cancel-url="cancelURL"
-              :locale="stripeLanguage"
+              :locale="language"
               @loading="v => loading = v"
             />
             <span v-for="(item) in stripeOneTimeDonations" :key="item.price">
@@ -229,7 +229,6 @@ export default {
       successURL: `${location.origin}/${this.$i18n.i18next.language}/donate?stripeSessionId={CHECKOUT_SESSION_ID}`,
       cancelURL: `${location.origin}/${this.$i18n.i18next.language}/donate`,
       language: `${this.$i18n.i18next.language}`,
-      stripeLanguage: `${this.$i18n.i18next.language=='hr'?'auto':this.$i18n.i18next.language}`,
     };
   },
   methods: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,10 +1655,12 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vue-stripe/vue-stripe@^4.0.0-beta.0":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@vue-stripe/vue-stripe/-/vue-stripe-4.0.3.tgz#4d503434857757fdaeb848f1efd7027f1d58212b"
-  integrity sha512-+GoKNZ4Hf02LIKNCBui86RvJnzsWjGun+lMLhEr+hYI2NT7OsiKgPJe9fkjUYfemlmD5yASBfVI1n24B+HqIDw==
+"@vue-stripe/vue-stripe@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@vue-stripe/vue-stripe/-/vue-stripe-4.1.1.tgz#37bd70e9d74a9a18566ee0c048a6aac17746a8e7"
+  integrity sha512-ME3U0kq/c8OuAYgYfcpqNUUPFlqvvVllI/TV813pwx+DzPtznTZNfQNT+3fbxPTJEV4r37yiqUPRo+3Kq2x3FQ==
+  dependencies:
+    vue-coerce-props "^1.0.0"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
   version "1.0.0"
@@ -11738,6 +11740,11 @@ vue-clickaway@^2.2.2:
   integrity sha512-25SpjXKetL06GLYoLoC8pqAV6Cur9cQ//2g35GRFBV4FgoljbZZjTINR8g2NuVXXDMLSUXaKx5dutgO4PaDE7A==
   dependencies:
     loose-envify "^1.2.0"
+
+vue-coerce-props@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vue-coerce-props/-/vue-coerce-props-1.0.0.tgz#af3d00aa419f0de79c2b020824c6c0387070d66e"
+  integrity sha512-4fdRMXO6FHzmE7H4soAph6QmPg3sL/RiGdd+axuxuU07f02LNMns0jMM88fmt1bvSbN+2Wyd8raho6p6nXUzag==
 
 vue-date-fns@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Vue stripe fixed a bug with unsupported languages https://github.com/vue-stripe/vue-stripe/issues/162 (croatian in our case)

We had a workaround for this bug in 97e86335e1c94dc79acefbdd0377eba3f348cd4b, but reverted in 0ef56aab0776a0927715f300bba5deb002da8f1f on this PR branch as the workaround is no longer needed.

When making a checkout vue now reports:
> VueStripe Warning: 'hr' is not supported by Stripe yet. Falling back to default 'auto'.

on the javascript console as expected and proceeds with `auto` language detection.

Thanks, @jofftiquez!