### PR TITLE
Fix display of InfoCards with large numbers

### DIFF
--- a/src/components/cards/InfoCard.vue
+++ b/src/components/cards/InfoCard.vue
@@ -143,7 +143,7 @@ export default {
     padding: 26px;
   }
 
-  @media only screen and (min-width: 768px) {
+  @media only screen and (min-width: 1200px) {
     padding: 20px 32px;
   }
 }


### PR DESCRIPTION
Fixes #881 
On screen widths from 768px to 1200px display of InfoCard with large number (vaccination) is a bit broken.
Main icon is cut off, second row is split into two lines (icon / number)