### PR TITLE
fix(sources-chart): do not use boost mode regardless of data point count

### DIFF
--- a/src/visualizations/SourcesChart.fs
+++ b/src/visualizations/SourcesChart.fs
@@ -401,6 +401,16 @@ let renderChartOptions (state: State) dispatch =
                                                 events = pojo {| click = onRangeSelectorButtonClick 2 |}
                                             |}
                                         |]
+           // As number of data points grow over time, HighCharts will kick into boost mode.
+           // For boost mode to work correctly, data points must be [x, y] pairs.
+           // Right now are data points are objects in order to shove in extra data for tooltips
+           // When performance without boost mode becomes a problem refactor tooltip formatting and use data points in [x, y] form.
+           //
+           // See:
+           //  - https://api.highcharts.com/highcharts/boost.seriesThreshold
+           //  - https://assets.highcharts.com/errors/12/
+           boost = pojo {|
+                          enabled = false |}
 
                                     |}
 


### PR DESCRIPTION
As the number of data points grows over time, HighCharts will kick into boost mode.
For boost mode to work correctly, data points must be [x, y] pairs.
Right now are data points are objects in order to shove in extra data for tooltips
When performance without boost mode becomes a problem refactor tooltip formatting and use data points in [x, y] form.

See:
  - https://api.highcharts.com/highcharts/boost.seriesThreshold
  - https://assets.highcharts.com/errors/12