### PR TITLE
Fix Patients charts not showing data after 1000 datapoints

### DIFF
--- a/src/visualizations/PatientsChart.fs
+++ b/src/visualizations/PatientsChart.fs
@@ -407,6 +407,7 @@ let renderStructureChart (state: State) dispatch =
                           pojo
                               {| dataGrouping = pojo {| enabled = false |}
                                  stacking = "normal"
+                                 turboThreshold = 0
                                  crisp = false
                                  borderWidth = 0
                                  pointPadding = 0


### PR DESCRIPTION
Fixes charts:
- Patients
- IcuPatients
- CarePatients